### PR TITLE
feat(db): add Giza Vaults DB (Postgres) + ClickHouse analytics stack

### DIFF
--- a/db/giza-vaults/.gitignore
+++ b/db/giza-vaults/.gitignore
@@ -1,0 +1,7 @@
+# Local secrets & volumes for DB subproject
+.env
+.env.*
+_pgdata/
+_pgadmin/
+ops/SET_ROLE_PASSWORDS.sql
+node_modules/

--- a/db/giza-vaults/README.md
+++ b/db/giza-vaults/README.md
@@ -1,62 +1,6 @@
-# Giza Agent Vaults DB
+# Giza Vaults DB — engines
 
-Normalized Postgres schema and views to store and query: Factory → Vaults → User mapping → Execution history. Powers `/agent/{chain_id}/giza/{vault_address}/tx_history`.
+- **Postgres** (original dev setup): [`postgres/`](postgres/README.md)
+- **ClickHouse** (analytics, columnar): [`clickhouse/`](clickhouse/README_CH.md)
 
-## Structure
-
-* `migrations/` – schema as code (**run in order**: `0001_init.sql` → `0003_upserts.sql` → `0002_views.sql` → `0004_roles.sql`)
-* `seeds/` – sample data (optional smoke test; uses the upsert functions)
-* `scripts/` – ingest/API helpers (to be finalized with subgraph + Giza API)
-* `docs/er.md` – ER diagram (Mermaid)
-* `ops/SET_ROLE_PASSWORDS.sql.example` – template to set per-environment role passwords (copy, fill, run; **do not commit** the filled copy)
-
-## Endpoints supported (via SQL views)
-
-* `/agent/{chain_id}/giza/{vault_address}/tx_history` ⇒ `v_agent_tx_history`
-
-**Use this query in the route handler:**
-
-```sql
-SELECT *
-FROM v_agent_tx_history
-WHERE chain_id = $1 AND vault_address = $2
-ORDER BY timestamp DESC
-LIMIT $3 OFFSET $4;
-```
-
-## Quick start (local)
-
-```bash
-# 1) copy env
-cp .env.example .env   # set POSTGRES_PASSWORD etc.
-
-# 2) run DB + pgAdmin (Postgres on localhost:5433, pgAdmin on http://localhost:8081)
-docker compose up -d
-
-# 3) apply migrations (order matters)
-#    0001_init.sql -> 0003_upserts.sql -> 0002_views.sql -> 0004_roles.sql
-#    (via pgAdmin Query Tool or CLI: docker cp + psql -f)
-
-# 4) (optional) set app role passwords
-#    copy ops/SET_ROLE_PASSWORDS.sql.example -> ops/SET_ROLE_PASSWORDS.sql
-#    fill passwords and run it once (do NOT commit the filled file)
-
-# 5) (optional) seed & test
-#    run seeds/seed.sql, then:
-#    SELECT * FROM v_agent_tx_history ORDER BY timestamp DESC LIMIT 20;
-```
-
-## Which credentials to use
-
-* **Migrations / local admin:** `giza / <POSTGRES_PASSWORD>`
-* **Ingest service (pipeline):** `etl_writer / <ETL_PASSWORD>`
-* **Read API / backend:** `api_reader / <API_PASSWORD>`
-
-> If a service runs inside the same Docker network as Postgres, use `host=db` and `port=5432`.
-> From your host machine, use `host=localhost` (or `127.0.0.1`) and `port=5433`.
-
-## Notes
-
-* Vaults are unique on `(chain_id, vault_address)`.
-* Executions are unique on `(tx_hash, vault_id)`; status can be updated safely (idempotent upserts).
-* Views give a stable API shape while we evolve internals.
+Pick the engine folder and follow its README.

--- a/db/giza-vaults/README.md
+++ b/db/giza-vaults/README.md
@@ -1,0 +1,62 @@
+# Giza Agent Vaults DB
+
+Normalized Postgres schema and views to store and query: Factory → Vaults → User mapping → Execution history. Powers `/agent/{chain_id}/giza/{vault_address}/tx_history`.
+
+## Structure
+
+* `migrations/` – schema as code (**run in order**: `0001_init.sql` → `0003_upserts.sql` → `0002_views.sql` → `0004_roles.sql`)
+* `seeds/` – sample data (optional smoke test; uses the upsert functions)
+* `scripts/` – ingest/API helpers (to be finalized with subgraph + Giza API)
+* `docs/er.md` – ER diagram (Mermaid)
+* `ops/SET_ROLE_PASSWORDS.sql.example` – template to set per-environment role passwords (copy, fill, run; **do not commit** the filled copy)
+
+## Endpoints supported (via SQL views)
+
+* `/agent/{chain_id}/giza/{vault_address}/tx_history` ⇒ `v_agent_tx_history`
+
+**Use this query in the route handler:**
+
+```sql
+SELECT *
+FROM v_agent_tx_history
+WHERE chain_id = $1 AND vault_address = $2
+ORDER BY timestamp DESC
+LIMIT $3 OFFSET $4;
+```
+
+## Quick start (local)
+
+```bash
+# 1) copy env
+cp .env.example .env   # set POSTGRES_PASSWORD etc.
+
+# 2) run DB + pgAdmin (Postgres on localhost:5433, pgAdmin on http://localhost:8081)
+docker compose up -d
+
+# 3) apply migrations (order matters)
+#    0001_init.sql -> 0003_upserts.sql -> 0002_views.sql -> 0004_roles.sql
+#    (via pgAdmin Query Tool or CLI: docker cp + psql -f)
+
+# 4) (optional) set app role passwords
+#    copy ops/SET_ROLE_PASSWORDS.sql.example -> ops/SET_ROLE_PASSWORDS.sql
+#    fill passwords and run it once (do NOT commit the filled file)
+
+# 5) (optional) seed & test
+#    run seeds/seed.sql, then:
+#    SELECT * FROM v_agent_tx_history ORDER BY timestamp DESC LIMIT 20;
+```
+
+## Which credentials to use
+
+* **Migrations / local admin:** `giza / <POSTGRES_PASSWORD>`
+* **Ingest service (pipeline):** `etl_writer / <ETL_PASSWORD>`
+* **Read API / backend:** `api_reader / <API_PASSWORD>`
+
+> If a service runs inside the same Docker network as Postgres, use `host=db` and `port=5432`.
+> From your host machine, use `host=localhost` (or `127.0.0.1`) and `port=5433`.
+
+## Notes
+
+* Vaults are unique on `(chain_id, vault_address)`.
+* Executions are unique on `(tx_hash, vault_id)`; status can be updated safely (idempotent upserts).
+* Views give a stable API shape while we evolve internals.

--- a/db/giza-vaults/clickhouse/.gitignore
+++ b/db/giza-vaults/clickhouse/.gitignore
@@ -1,0 +1,7 @@
+@"
+.env
+.env.*
+_ch_data/
+ops/CH_SET_PASSWORDS.sql
+node_modules/
+"@ | Set-Content -Path "db/giza-vaults/clickhouse/.gitignore"

--- a/db/giza-vaults/clickhouse/README_CH.md
+++ b/db/giza-vaults/clickhouse/README_CH.md
@@ -1,0 +1,23 @@
+# Giza Vaults DB — ClickHouse
+
+
+This folder provides a ClickHouse setup for the Giza Vaults analytics DB.
+
+
+## Why ClickHouse (changes from Postgres)
+- Columnar storage, vectorized execution, and MergeTree engines provide very fast analytics.
+- We use **natural keys** (e.g., `chain_id + vault_address`) instead of surrogate `vault_id`.
+- Dedup & updates use **ReplacingMergeTree(version)** instead of `UPSERT`.
+- Pre-computed views use **Materialized Views**.
+
+
+## Quick start (Windows / PowerShell)
+```powershell
+cd db/giza-vaults/clickhouse
+cp .env.example .env # then edit CH_PASSWORD
+# Start DB
+docker compose up -d
+# (If init scripts didn’t run) run migrations manually
+pwsh ./scripts/ch_migrate.ps1
+# Smoke test
+pwsh ./scripts/ch_smoke.ps1

--- a/db/giza-vaults/clickhouse/docker-compose.yml
+++ b/db/giza-vaults/clickhouse/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  ch:
+    image: clickhouse/clickhouse-server:25.6
+    container_name: giza_clickhouse
+    ports:
+      - "8123:8123"   # HTTP
+      - "9000:9000"   # Native TCP
+    environment:
+      CLICKHOUSE_DB: giza
+      CLICKHOUSE_USER: giza
+      CLICKHOUSE_PASSWORD: ${CH_PASSWORD:-giza_pw_change_me}
+      CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: "1"
+    volumes:
+      - ./_ch_data:/var/lib/clickhouse
+      - ./init:/docker-entrypoint-initdb.d
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144

--- a/db/giza-vaults/clickhouse/docs/er_agents_core.md
+++ b/db/giza-vaults/clickhouse/docs/er_agents_core.md
@@ -1,0 +1,100 @@
+# ER Diagram — Agents (core ingest + serving)
+
+```mermaid
+erDiagram
+  %% Core relationships (agent-agnostic)
+  AGENTS        ||--o{ AGENT_VAULTS     : has
+  VAULTS        ||--o{ AGENT_VAULTS     : maps
+  VAULTS        ||--o{ USER_VAULTS      : links
+  VAULTS        ||--o{ EXECUTIONS       : records
+  USER_VAULTS   ||--o{ EXECUTIONS_FLAT  : enriches
+  EXECUTIONS    ||--o{ EXECUTIONS_FLAT  : materializes
+
+  AGENTS {
+    string  agent_id
+    string  agent_name
+    string  model_type
+    string  owner_address
+    date    deployment_date
+    string  website
+    string  category
+    string[] tags
+    string  status
+    string[] chain_ids
+  }
+
+  VAULTS {
+    string  chain_id
+    string  factory_address
+    string  vault_address
+    datetime created_at
+    uint64  created_block
+  }
+
+  AGENT_VAULTS {
+    string  chain_id
+    string  vault_address
+    string  agent_id
+    string  agent_name
+    datetime linked_at
+  }
+
+  USER_VAULTS {
+    string  chain_id
+    string  vault_address
+    string  wallet_address
+    datetime linked_at
+  }
+
+  EXECUTIONS {
+    string  chain_id
+    string  agent_name
+    string  vault_address
+    string  tx_hash
+    uint16  log_index
+    uint64  block_number
+    datetime timestamp
+    datetime block_timestamp
+    string  action_type
+    string  status
+    string  asset_symbol
+    string  asset_address
+    uint8   asset_decimals
+    decimal amount_asset
+    decimal amount_usd
+    decimal price_usd
+    decimal fee_usd
+    decimal realized_pnl_usd
+    string  protocol
+    string  from_protocol
+    string  to_protocol
+    string  exchange
+    float   apy_at_execution
+  }
+
+  EXECUTIONS_FLAT {
+    string  chain_id
+    string  agent_name
+    string  vault_address
+    string  wallet_address
+    string  tx_hash
+    uint16  log_index
+    uint64  block_number
+    datetime timestamp
+    datetime block_timestamp
+    string  action_type
+    string  status
+    string  asset_symbol
+    string  asset_address
+    uint8   asset_decimals
+    decimal amount_asset
+    decimal amount_usd
+    decimal price_usd
+    decimal fee_usd
+    decimal realized_pnl_usd
+    string  protocol
+    string  from_protocol
+    string  to_protocol
+    string  exchange
+    float   apy_at_execution
+  }

--- a/db/giza-vaults/clickhouse/docs/er_agents_daily.md
+++ b/db/giza-vaults/clickhouse/docs/er_agents_daily.md
@@ -1,0 +1,189 @@
+```md
+# ER Diagram — Agents (daily rollups)
+
+```mermaid
+erDiagram
+  %% Daily rollups share keys: asof_date (+ chain_id / agent_id / agent_name)
+
+  AGENTS ||--o{ AGENT_IDENTITY_DAILY : identity
+  AGENTS ||--o{ AGENT_CONTRACTS_DAILY : contracts
+  AGENTS ||--o{ AGENT_USERS_DAILY : users
+  AGENTS ||--o{ STRATEGIES_DAILY : strategies
+  AGENTS ||--o{ ASSET_DAILY : tvl
+  AGENTS ||--o{ EXEC_STATS_DAILY : execstats
+  AGENTS ||--o{ RETURNS_DAILY : returns
+  AGENTS ||--o{ TVL_LEDGER_DAILY : tvl_ledger
+  AGENTS ||--o{ HOLDINGS_DAILY : holdings
+
+  CHAIN_TOTAL_TVL_DAILY ||--o{ RISKFREE_DAILY : market
+  DEPLOYED_AGENTS_ON_PROJECT_DAILY ||--o{ CHAIN_TOTAL_DEPLOYED_AGENTS_DAILY : counts
+  POOLS_DEPTH_DAILY ||--o{ SENTIMENT_DAILY : context
+
+  AGENT_IDENTITY_DAILY {
+    string  agent_id
+    string  agent_name
+    date    asof_date
+    datetime block_timestamp
+    decimal asset_under_management
+    string  website
+    string  category
+    string[] tags
+    string  status
+    string[] chain_ids
+  }
+
+  AGENT_CONTRACTS_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    string[] primary_contracts
+    string  share_token
+    string[] underlying_tokens
+    uint8   is_erc4626
+    string  proxy_address
+    string  implementation_address
+    uint64  start_block
+    datetime first_deploy_ts
+  }
+
+  AGENT_USERS_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    uint64  unique_depositors_cumulative
+    uint64  unique_depositors_30d
+    uint64  active_wallets_30d
+  }
+
+  STRATEGIES_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    string  strategy_id
+    string  protocol_name
+    string[] asset_pairs
+    string  status
+  }
+
+  ASSET_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    decimal tvl_usd
+    decimal total_shares
+    decimal total_assets
+  }
+
+  EXEC_STATS_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    uint64  success_calls
+    uint64  failed_calls
+  }
+
+  RETURNS_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    float   ret_pct
+  }
+
+  RISKFREE_DAILY {
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    float   rf_rate_daily
+  }
+
+  LOSS_EVENTS {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    datetime ts
+    date    asof_date
+    decimal value_before_usd
+    decimal value_after_usd
+    float   loss_pct
+    string  tx_hash
+  }
+
+  TVL_LEDGER_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    decimal tvl_usd_today
+    decimal lifetime_deposits_usd
+  }
+
+  HOLDINGS_DAILY {
+    string  agent_id
+    string  agent_name
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    string  token_address
+    string  token_symbol
+    uint8   token_decimals
+    decimal balance
+    decimal usd_value
+  }
+
+  CHAIN_TOTAL_TVL_DAILY {
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    decimal tvl_usd
+  }
+
+  CHAIN_TOTAL_DEPLOYED_AGENTS_DAILY {
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    uint64  total_agents
+  }
+
+  DEPLOYED_AGENTS_ON_PROJECT_DAILY {
+    string  chain_id
+    string  agent_name
+    date    asof_date
+    datetime block_timestamp
+    uint64  deployed_agents_count
+  }
+
+  POOLS_DEPTH_DAILY {
+    string  chain_id
+    date    asof_date
+    datetime block_timestamp
+    string  pool_address
+    string  token0
+    string  token1
+    decimal reserve0
+    decimal reserve1
+    decimal depth_1pct_usd
+  }
+
+  SENTIMENT_DAILY {
+    date    asof_date
+    datetime block_timestamp
+    string[] project_handles
+    string[] contract_addresses
+    float   sentiment_avg
+    float   volume
+    float   criticism_severity
+    uint64  reputation_mentions
+  }

--- a/db/giza-vaults/clickhouse/docs/er_agents_daily.md
+++ b/db/giza-vaults/clickhouse/docs/er_agents_daily.md
@@ -1,4 +1,3 @@
-```md
 # ER Diagram — Agents (daily rollups)
 
 ```mermaid

--- a/db/giza-vaults/clickhouse/docs/er_clickhouse.md
+++ b/db/giza-vaults/clickhouse/docs/er_clickhouse.md
@@ -1,0 +1,52 @@
+# ER Diagram — ClickHouse (natural keys)
+
+
+```mermaid
+erDiagram
+USERS ||--o{ USER_VAULTS : maps
+VAULTS ||--o{ USER_VAULTS : maps
+VAULTS ||--o{ EXECUTIONS : records
+
+
+USERS {
+string wallet_address PK
+datetime first_seen_at
+}
+
+
+VAULTS {
+string chain_id PK
+string vault_address PK
+string factory_address
+datetime created_at
+uint64 created_block
+}
+
+
+USER_VAULTS {
+string chain_id FK
+string vault_address FK
+string wallet_address FK
+datetime linked_at
+}
+
+
+EXECUTIONS {
+string chain_id FK
+string vault_address FK
+string tx_hash
+uint16 log_index
+uint64 block_number
+datetime timestamp
+string action_type
+enum status
+string asset_symbol
+string asset_address
+uint8 asset_decimals
+decimal amount_asset(38,18)
+decimal amount_usd(38,6)
+string protocol
+string from_protocol
+string to_protocol
+float apy_at_execution
+}

--- a/db/giza-vaults/clickhouse/docs/er_clickhouse.md
+++ b/db/giza-vaults/clickhouse/docs/er_clickhouse.md
@@ -2,6 +2,9 @@
 
 ```mermaid
 erDiagram
+  %% amount_asset: Decimal128 scale 18 (ClickHouse)
+  %% amount_usd:   Decimal128 scale 6  (ClickHouse)
+
   USERS  ||--o{ USER_VAULTS : maps
   VAULTS ||--o{ USER_VAULTS : maps
   VAULTS ||--o{ EXECUTIONS  : records
@@ -38,8 +41,8 @@ erDiagram
     string  asset_symbol
     string  asset_address
     uint8   asset_decimals
-    decimal amount_asset    %% Decimal128 scale 18 in CH
-    decimal amount_usd      %% Decimal128 scale 6 in CH
+    decimal amount_asset
+    decimal amount_usd
     string  protocol
     string  from_protocol
     string  to_protocol

--- a/db/giza-vaults/clickhouse/docs/er_clickhouse.md
+++ b/db/giza-vaults/clickhouse/docs/er_clickhouse.md
@@ -1,52 +1,47 @@
 # ER Diagram — ClickHouse (natural keys)
 
-
 ```mermaid
 erDiagram
-USERS ||--o{ USER_VAULTS : maps
-VAULTS ||--o{ USER_VAULTS : maps
-VAULTS ||--o{ EXECUTIONS : records
+  USERS  ||--o{ USER_VAULTS : maps
+  VAULTS ||--o{ USER_VAULTS : maps
+  VAULTS ||--o{ EXECUTIONS  : records
 
+  USERS {
+    string wallet_address
+    datetime first_seen_at
+  }
 
-USERS {
-string wallet_address PK
-datetime first_seen_at
-}
+  VAULTS {
+    string chain_id
+    string vault_address
+    string factory_address
+    datetime created_at
+    uint64  created_block
+  }
 
+  USER_VAULTS {
+    string chain_id
+    string vault_address
+    string wallet_address
+    datetime linked_at
+  }
 
-VAULTS {
-string chain_id PK
-string vault_address PK
-string factory_address
-datetime created_at
-uint64 created_block
-}
-
-
-USER_VAULTS {
-string chain_id FK
-string vault_address FK
-string wallet_address FK
-datetime linked_at
-}
-
-
-EXECUTIONS {
-string chain_id FK
-string vault_address FK
-string tx_hash
-uint16 log_index
-uint64 block_number
-datetime timestamp
-string action_type
-enum status
-string asset_symbol
-string asset_address
-uint8 asset_decimals
-decimal amount_asset(38,18)
-decimal amount_usd(38,6)
-string protocol
-string from_protocol
-string to_protocol
-float apy_at_execution
-}
+  EXECUTIONS {
+    string  chain_id
+    string  vault_address
+    string  tx_hash
+    uint16  log_index
+    uint64  block_number
+    datetime timestamp
+    string  action_type
+    string  status
+    string  asset_symbol
+    string  asset_address
+    uint8   asset_decimals
+    decimal amount_asset    %% Decimal128 scale 18 in CH
+    decimal amount_usd      %% Decimal128 scale 6 in CH
+    string  protocol
+    string  from_protocol
+    string  to_protocol
+    float   apy_at_execution
+  }

--- a/db/giza-vaults/clickhouse/docs/er_clickhouse_flat.md
+++ b/db/giza-vaults/clickhouse/docs/er_clickhouse_flat.md
@@ -2,8 +2,6 @@
 
 ```mermaid
 erDiagram
-  %% executions_flat is the serving table most queries hit
-
   EXECUTIONS_FLAT {
     string  chain_id
     string  vault_address
@@ -17,8 +15,8 @@ erDiagram
     string  asset_symbol
     string  asset_address
     uint8   asset_decimals
-    decimal amount_asset   %% CH Decimal128(18)
-    decimal amount_usd     %% CH Decimal128(6)
+    decimal amount_asset
+    decimal amount_usd
     string  protocol
     string  from_protocol
     string  to_protocol

--- a/db/giza-vaults/clickhouse/docs/er_clickhouse_flat.md
+++ b/db/giza-vaults/clickhouse/docs/er_clickhouse_flat.md
@@ -1,0 +1,26 @@
+# ER Diagram — ClickHouse “one big table” (serving)
+
+```mermaid
+erDiagram
+  %% executions_flat is the serving table most queries hit
+
+  EXECUTIONS_FLAT {
+    string  chain_id
+    string  vault_address
+    string  wallet_address
+    string  tx_hash
+    uint16  log_index
+    uint64  block_number
+    datetime timestamp
+    string  action_type
+    string  status
+    string  asset_symbol
+    string  asset_address
+    uint8   asset_decimals
+    decimal amount_asset   %% CH Decimal128(18)
+    decimal amount_usd     %% CH Decimal128(6)
+    string  protocol
+    string  from_protocol
+    string  to_protocol
+    float   apy_at_execution
+  }

--- a/db/giza-vaults/clickhouse/migrations/0001_tables.sql
+++ b/db/giza-vaults/clickhouse/migrations/0001_tables.sql
@@ -1,0 +1,76 @@
+-- Create DB (idempotent)
+CREATE DATABASE IF NOT EXISTS giza;
+
+-- ============ Dimension-ish tables (natural keys) ============
+
+CREATE TABLE IF NOT EXISTS giza.vaults
+(
+  chain_id        LowCardinality(String),
+  factory_address String,
+  vault_address   String,
+  created_at      DateTime64(3, 'UTC'),
+  created_block   UInt64,
+  ingest_ts       DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+PARTITION BY (chain_id)
+ORDER BY (chain_id, vault_address);
+
+CREATE TABLE IF NOT EXISTS giza.users
+(
+  wallet_address String,
+  first_seen_at  DateTime64(3, 'UTC') DEFAULT now(),
+  ingest_ts      DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+ORDER BY (wallet_address);
+
+CREATE TABLE IF NOT EXISTS giza.user_vaults
+(
+  chain_id       LowCardinality(String),
+  vault_address  String,
+  wallet_address String,
+  linked_at      DateTime64(3, 'UTC') DEFAULT now(),
+  ingest_ts      DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id)
+ORDER BY (chain_id, vault_address, wallet_address);
+
+-- ============ Fact: executions (atomic actions) ============
+
+CREATE TABLE IF NOT EXISTS giza.executions
+(
+  chain_id         LowCardinality(String),
+  vault_address    String,
+
+  -- tx identity
+  tx_hash          String,
+  log_index        UInt16 DEFAULT 0,
+  block_number     UInt64,
+  timestamp        DateTime64(3, 'UTC'),
+
+  -- action & status
+  action_type      LowCardinality(String),   -- deposit/withdraw/transfer
+  status           Enum8('completed' = 1, 'failed' = 2, 'pending' = 3),
+
+  -- asset & amounts
+  asset_symbol     LowCardinality(String),
+  asset_address    String,
+  asset_decimals   UInt8,
+  amount_asset     Decimal128(18),           -- token units
+  amount_usd       Decimal128(6),            -- USD value at exec time
+
+  -- protocols / routing
+  protocol         LowCardinality(String),
+  from_protocol    LowCardinality(String),
+  to_protocol      LowCardinality(String),
+
+  -- meta
+  apy_at_execution Float64,
+  ingest_ts        DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(timestamp))
+ORDER BY (chain_id, toDate(timestamp), vault_address, tx_hash, log_index)
+SETTINGS index_granularity = 8192;

--- a/db/giza-vaults/clickhouse/migrations/0002_views.sql
+++ b/db/giza-vaults/clickhouse/migrations/0002_views.sql
@@ -1,0 +1,35 @@
+-- Flat tx history view for API
+CREATE OR REPLACE VIEW giza.v_agent_tx_history AS
+SELECT
+chain_id,
+vault_address,
+timestamp,
+action_type,
+status,
+asset_symbol,
+asset_address,
+asset_decimals,
+amount_asset,
+amount_usd,
+protocol,
+from_protocol,
+to_protocol,
+apy_at_execution,
+tx_hash,
+block_number,
+log_index
+FROM giza.executions;
+
+
+-- Example aggregates (read-mostly analytics)
+CREATE OR REPLACE VIEW giza.v_user_agg_30d AS
+SELECT
+uv.wallet_address,
+e.chain_id,
+sumIf(e.amount_usd, e.action_type = 'deposit' AND e.status = 'completed' AND e.timestamp >= now() - INTERVAL 30 DAY) AS deposits_30d_usd,
+sumIf(e.amount_usd, e.action_type = 'withdraw' AND e.status = 'completed' AND e.timestamp >= now() - INTERVAL 30 DAY) AS withdrawals_30d_usd,
+uniqExactIf(e.tx_hash, e.status = 'failed' AND e.timestamp >= now() - INTERVAL 30 DAY) AS failed_txs_30d
+FROM giza.user_vaults uv
+JOIN giza.executions e
+ON e.chain_id = uv.chain_id AND e.vault_address = uv.vault_address
+GROUP BY uv.wallet_address, e.chain_id;

--- a/db/giza-vaults/clickhouse/migrations/0003_access.sql
+++ b/db/giza-vaults/clickhouse/migrations/0003_access.sql
@@ -1,0 +1,26 @@
+-- Enable RBAC if not already enabled via env: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+
+
+-- Roles
+CREATE ROLE IF NOT EXISTS etl_writer;
+CREATE ROLE IF NOT EXISTS api_reader;
+
+
+-- Users (no passwords here; set in ops file)
+CREATE USER IF NOT EXISTS etl_svc;
+CREATE USER IF NOT EXISTS api_svc;
+
+
+-- Grants
+GRANT INSERT, SELECT ON giza.executions TO etl_writer;
+GRANT INSERT, SELECT ON giza.vaults TO etl_writer;
+GRANT INSERT, SELECT ON giza.users TO etl_writer;
+GRANT INSERT, SELECT ON giza.user_vaults TO etl_writer;
+
+
+GRANT SELECT ON giza.v_agent_tx_history TO api_reader;
+GRANT SELECT ON giza.v_user_agg_30d TO api_reader;
+
+
+GRANT etl_writer TO etl_svc;
+GRANT api_reader TO api_svc;

--- a/db/giza-vaults/clickhouse/migrations/0004_flatten.sql
+++ b/db/giza-vaults/clickhouse/migrations/0004_flatten.sql
@@ -1,0 +1,91 @@
+-- 1) Target flattened table (the “one giant table” you query)
+CREATE TABLE IF NOT EXISTS giza.executions_flat
+(
+  chain_id         LowCardinality(String),
+  vault_address    String,
+  wallet_address   String,                -- admin/user mapped at insert time
+
+  tx_hash          String,
+  log_index        UInt16,
+  block_number     UInt64,
+  timestamp        DateTime64(3, 'UTC'),
+
+  action_type      LowCardinality(String),
+  status           LowCardinality(String),-- keep as string here for simpler tooling
+  asset_symbol     LowCardinality(String),
+  asset_address    String,
+  asset_decimals   UInt8,
+  amount_asset     Decimal128(18),
+  amount_usd       Decimal128(6),
+  protocol         LowCardinality(String),
+  from_protocol    LowCardinality(String),
+  to_protocol      LowCardinality(String),
+  apy_at_execution Float64,
+
+  ingest_ts        DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(timestamp))
+ORDER BY (chain_id, toDate(timestamp), wallet_address, vault_address, tx_hash, log_index);
+
+-- 2) Materialized view: on every INSERT into executions, populate executions_flat
+--    ANY LEFT JOIN chooses one admin if multiple exist (most vaults have few admins).
+--    If you need *all* admins, we can switch to an explode approach later.
+CREATE MATERIALIZED VIEW IF NOT EXISTS giza.mv_executions_to_flat
+TO giza.executions_flat
+AS
+SELECT
+  e.chain_id,
+  e.vault_address,
+  uv.wallet_address,
+
+  e.tx_hash,
+  e.log_index,
+  e.block_number,
+  e.timestamp,
+
+  e.action_type,
+  CAST(e.status AS String) AS status,
+  e.asset_symbol,
+  e.asset_address,
+  e.asset_decimals,
+  e.amount_asset,
+  e.amount_usd,
+  e.protocol,
+  e.from_protocol,
+  e.to_protocol,
+  e.apy_at_execution,
+
+  e.ingest_ts
+FROM giza.executions AS e
+LEFT ANY JOIN giza.user_vaults AS uv
+  ON uv.chain_id = e.chain_id AND uv.vault_address = e.vault_address;
+
+-- 3) Backfill existing data once (safe to re-run: ReplacingMergeTree dedupes on ORDER BY)
+INSERT INTO giza.executions_flat
+SELECT
+  e.chain_id,
+  e.vault_address,
+  uv.wallet_address,
+
+  e.tx_hash,
+  e.log_index,
+  e.block_number,
+  e.timestamp,
+
+  e.action_type,
+  CAST(e.status AS String) AS status,
+  e.asset_symbol,
+  e.asset_address,
+  e.asset_decimals,
+  e.amount_asset,
+  e.amount_usd,
+  e.protocol,
+  e.from_protocol,
+  e.to_protocol,
+  e.apy_at_execution,
+
+  e.ingest_ts
+FROM giza.executions AS e
+LEFT ANY JOIN giza.user_vaults AS uv
+  ON uv.chain_id = e.chain_id AND uv.vault_address = e.vault_address;

--- a/db/giza-vaults/clickhouse/migrations/0005_views_update.sql
+++ b/db/giza-vaults/clickhouse/migrations/0005_views_update.sql
@@ -1,0 +1,21 @@
+CREATE OR REPLACE VIEW giza.v_agent_tx_history AS
+SELECT
+  chain_id,
+  vault_address,
+  wallet_address,   -- now included
+  timestamp,
+  action_type,
+  status,
+  asset_symbol,
+  asset_address,
+  asset_decimals,
+  amount_asset,
+  amount_usd,
+  protocol,
+  from_protocol,
+  to_protocol,
+  apy_at_execution,
+  tx_hash,
+  block_number,
+  log_index
+FROM giza.executions_flat;

--- a/db/giza-vaults/clickhouse/migrations/0009_namespace_agents.sql
+++ b/db/giza-vaults/clickhouse/migrations/0009_namespace_agents.sql
@@ -1,0 +1,478 @@
+/* 1) Create generic namespace */
+CREATE DATABASE IF NOT EXISTS agents;
+
+/* ---------- Core tables (agent-agnostic) ---------- */
+CREATE TABLE IF NOT EXISTS agents.agents
+(
+  agent_id        String,
+  agent_name      String,
+  model_type      LowCardinality(String),
+  owner_address   String,
+  deployment_date Date,
+  website         String,
+  category        LowCardinality(String),
+  tags            Array(String),
+  status          LowCardinality(String),
+  chain_ids       Array(String),
+  ingest_ts       DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+ORDER BY (agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.vaults
+(
+  chain_id        LowCardinality(String),
+  factory_address String,
+  vault_address   String,
+  created_at      DateTime64(3, 'UTC'),
+  created_block   UInt64,
+  ingest_ts       DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+PARTITION BY (chain_id)
+ORDER BY (chain_id, vault_address);
+
+CREATE TABLE IF NOT EXISTS agents.user_vaults
+(
+  chain_id       LowCardinality(String),
+  vault_address  String,
+  wallet_address String,
+  linked_at      DateTime64(3, 'UTC') DEFAULT now(),
+  ingest_ts      DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id)
+ORDER BY (chain_id, vault_address, wallet_address);
+
+CREATE TABLE IF NOT EXISTS agents.agent_vaults
+(
+  chain_id      LowCardinality(String),
+  vault_address String,
+  agent_id      String,
+  agent_name    String,
+  linked_at     DateTime64(3, 'UTC') DEFAULT now(),
+  ingest_ts     DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id)
+ORDER BY (chain_id, vault_address, agent_id);
+
+/* Canonical events (already extended for trading & “every record” fields) */
+CREATE TABLE IF NOT EXISTS agents.executions
+(
+  chain_id         LowCardinality(String),
+  agent_name       LowCardinality(String),
+  vault_address    String,
+
+  tx_hash          String,
+  log_index        UInt16 DEFAULT 0,
+  block_number     UInt64,
+  timestamp        DateTime64(3, 'UTC'),
+  block_timestamp  DateTime64(3, 'UTC') DEFAULT timestamp,
+
+  action_type      LowCardinality(String),
+  status           Enum8('completed' = 1, 'failed' = 2, 'pending' = 3),
+
+  asset_symbol     LowCardinality(String),
+  asset_address    String,
+  asset_decimals   UInt8,
+  amount_asset     Decimal128(18),
+  amount_usd       Decimal128(6),
+  price_usd        Decimal128(6) DEFAULT 0,
+  fee_usd          Decimal128(6) DEFAULT 0,
+  realized_pnl_usd Decimal128(6) DEFAULT 0,
+
+  protocol         LowCardinality(String),
+  from_protocol    LowCardinality(String),
+  to_protocol      LowCardinality(String),
+  exchange         LowCardinality(String) DEFAULT '',
+
+  apy_at_execution Float64,
+  ingest_ts        DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(timestamp))
+ORDER BY (chain_id, toDate(timestamp), vault_address, tx_hash, log_index)
+SETTINGS index_granularity = 8192;
+
+/* Flattened serving table (“one big table” reads) */
+CREATE TABLE IF NOT EXISTS agents.executions_flat
+(
+  chain_id         LowCardinality(String),
+  agent_name       LowCardinality(String),
+  vault_address    String,
+  wallet_address   String,
+
+  tx_hash          String,
+  log_index        UInt16,
+  block_number     UInt64,
+  timestamp        DateTime64(3, 'UTC'),
+  block_timestamp  DateTime64(3, 'UTC'),
+
+  action_type      LowCardinality(String),
+  status           LowCardinality(String),
+  asset_symbol     LowCardinality(String),
+  asset_address    String,
+  asset_decimals   UInt8,
+  amount_asset     Decimal128(18),
+  amount_usd       Decimal128(6),
+  price_usd        Decimal128(6),
+  fee_usd          Decimal128(6),
+  realized_pnl_usd Decimal128(6),
+  protocol         LowCardinality(String),
+  from_protocol    LowCardinality(String),
+  to_protocol      LowCardinality(String),
+  exchange         LowCardinality(String),
+  apy_at_execution Float64,
+
+  ingest_ts        DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(timestamp))
+ORDER BY (chain_id, toDate(timestamp), wallet_address, vault_address, tx_hash, log_index);
+
+/* Materialized view in the new namespace */
+CREATE MATERIALIZED VIEW IF NOT EXISTS agents.mv_executions_to_flat
+TO agents.executions_flat
+AS
+SELECT
+  e.chain_id,
+  av.agent_name,
+  e.vault_address,
+  uv.wallet_address,
+
+  e.tx_hash,
+  e.log_index,
+  e.block_number,
+  e.timestamp,
+  e.block_timestamp,
+
+  e.action_type,
+  CAST(e.status AS String) AS status,
+  e.asset_symbol,
+  e.asset_address,
+  e.asset_decimals,
+  e.amount_asset,
+  e.amount_usd,
+  e.price_usd,
+  e.fee_usd,
+  e.realized_pnl_usd,
+  e.protocol,
+  e.from_protocol,
+  e.to_protocol,
+  e.exchange,
+  e.apy_at_execution,
+
+  e.ingest_ts
+FROM agents.executions AS e
+LEFT ANY JOIN agents.user_vaults AS uv
+  ON uv.chain_id = e.chain_id AND uv.vault_address = e.vault_address
+LEFT ANY JOIN agents.agent_vaults AS av
+  ON av.chain_id = e.chain_id AND av.vault_address = e.vault_address;
+
+/* Generic API view */
+CREATE OR REPLACE VIEW agents.v_tx_history AS
+SELECT
+  chain_id,
+  agent_name,
+  vault_address,
+  wallet_address,
+  timestamp,
+  block_timestamp,
+  action_type,
+  status,
+  asset_symbol,
+  asset_address,
+  asset_decimals,
+  amount_asset,
+  amount_usd,
+  price_usd,
+  fee_usd,
+  realized_pnl_usd,
+  protocol,
+  from_protocol,
+  to_protocol,
+  exchange,
+  apy_at_execution,
+  tx_hash,
+  block_number,
+  log_index
+FROM agents.executions_flat;
+
+/* ---------- Daily rollup tables (agent-agnostic) ---------- */
+CREATE TABLE IF NOT EXISTS agents.agent_identity_daily
+(
+  agent_id      String,
+  agent_name    String,
+  asof_date     Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  asset_under_management Decimal128(6) DEFAULT 0,
+  website       String,
+  category      LowCardinality(String),
+  tags          Array(String),
+  status        LowCardinality(String),
+  chain_ids     Array(String),
+  ingest_ts     DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY toYYYYMM(asof_date)
+ORDER BY (asof_date, agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.agent_contracts_daily
+(
+  agent_id      String,
+  agent_name    String,
+  chain_id      LowCardinality(String),
+  asof_date     Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  primary_contracts  Array(String),
+  share_token        String,
+  underlying_tokens  Array(String),
+  is_erc4626         UInt8,
+  proxy_address      String,
+  implementation_address String,
+  start_block        UInt64,
+  first_deploy_ts    DateTime64(3, 'UTC'),
+  ingest_ts          DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.agent_users_daily
+(
+  agent_id      String,
+  agent_name    String,
+  chain_id      LowCardinality(String),
+  asof_date     Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  unique_depositors_cumulative UInt64,
+  unique_depositors_30d        UInt64,
+  active_wallets_30d           UInt64,
+  ingest_ts     DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.strategies_daily
+(
+  agent_id      String,
+  agent_name    String,
+  chain_id      LowCardinality(String),
+  asof_date     Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  strategy_id   String,
+  protocol_name LowCardinality(String),
+  asset_pairs   Array(String),
+  status        LowCardinality(String),
+  ingest_ts     DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id, strategy_id);
+
+CREATE TABLE IF NOT EXISTS agents.asset_daily
+(
+  agent_id    String,
+  agent_name  String,
+  chain_id    LowCardinality(String),
+  asof_date   Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  tvl_usd     Decimal128(6),
+  total_shares Decimal128(18),
+  total_assets Decimal128(18),
+  ingest_ts   DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.chain_total_tvl_daily
+(
+  chain_id  LowCardinality(String),
+  asof_date Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  tvl_usd   Decimal128(6),
+  ingest_ts DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY toYYYYMM(asof_date)
+ORDER BY (asof_date, chain_id);
+
+CREATE TABLE IF NOT EXISTS agents.chain_total_deployed_agents_daily
+(
+  chain_id  LowCardinality(String),
+  asof_date Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  total_agents UInt64,
+  ingest_ts DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY toYYYYMM(asof_date)
+ORDER BY (asof_date, chain_id);
+
+CREATE TABLE IF NOT EXISTS agents.deployed_agents_on_project_daily
+(
+  chain_id  LowCardinality(String),
+  agent_name String,
+  asof_date Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  deployed_agents_count UInt64,
+  ingest_ts DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY toYYYYMM(asof_date)
+ORDER BY (asof_date, chain_id, agent_name);
+
+CREATE TABLE IF NOT EXISTS agents.exec_stats_daily
+(
+  agent_id   String,
+  agent_name String,
+  chain_id   LowCardinality(String),
+  asof_date  Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  success_calls UInt64,
+  failed_calls  UInt64,
+  ingest_ts  DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.returns_daily
+(
+  agent_id   String,
+  agent_name String,
+  chain_id   LowCardinality(String),
+  asof_date  Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  ret_pct    Float64,
+  ingest_ts  DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.riskfree_daily
+(
+  chain_id   LowCardinality(String),
+  asof_date  Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  rf_rate_daily Float64,
+  ingest_ts  DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY toYYYYMM(asof_date)
+ORDER BY (asof_date, chain_id);
+
+CREATE TABLE IF NOT EXISTS agents.loss_events
+(
+  agent_id   String,
+  agent_name String,
+  chain_id   LowCardinality(String),
+  ts         DateTime64(3, 'UTC'),
+  asof_date  Date DEFAULT toDate(ts, 'UTC'),
+  value_before_usd Decimal128(6),
+  value_after_usd  Decimal128(6),
+  loss_pct   Float64,
+  tx_hash    String DEFAULT '',
+  ingest_ts  DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+PARTITION BY (chain_id, toYYYYMM(ts))
+ORDER BY (chain_id, toDate(ts), agent_id, ts);
+
+CREATE TABLE IF NOT EXISTS agents.tvl_ledger_daily
+(
+  agent_id   String,
+  agent_name String,
+  chain_id   LowCardinality(String),
+  asof_date  Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  tvl_usd_today         Decimal128(6),
+  lifetime_deposits_usd Decimal128(6),
+  ingest_ts  DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.holdings_daily
+(
+  agent_id     String,
+  agent_name   String,
+  chain_id     LowCardinality(String),
+  asof_date    Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  token_address String,
+  token_symbol  LowCardinality(String) DEFAULT '',
+  token_decimals UInt8 DEFAULT 18,
+  balance       Decimal128(18),
+  usd_value     Decimal128(6),
+  ingest_ts     DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, agent_id, token_address);
+
+CREATE TABLE IF NOT EXISTS agents.pools_depth_daily
+(
+  chain_id     LowCardinality(String),
+  asof_date    Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  pool_address String,
+  token0       String,
+  token1       String,
+  reserve0     Decimal128(18),
+  reserve1     Decimal128(18),
+  depth_1pct_usd Decimal128(6),
+  ingest_ts    DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(asof_date))
+ORDER BY (chain_id, asof_date, pool_address);
+
+CREATE TABLE IF NOT EXISTS agents.sentiment_daily
+(
+  asof_date    Date,
+  block_timestamp DateTime64(3, 'UTC') DEFAULT now(),
+  project_handles Array(String),
+  contract_addresses Array(String),
+  sentiment_avg  Float64,
+  volume         Float64,
+  criticism_severity Float64,
+  reputation_mentions UInt64,
+  ingest_ts      DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY toYYYYMM(asof_date)
+ORDER BY (asof_date);
+
+/* ---------- Copy data from old namespace (if present) ---------- */
+INSERT INTO agents.vaults        SELECT * FROM giza.vaults;
+INSERT INTO agents.user_vaults   SELECT * FROM giza.user_vaults;
+INSERT INTO agents.agent_vaults  SELECT * FROM giza.agent_vaults;
+INSERT INTO agents.executions    SELECT * FROM giza.executions;
+INSERT INTO agents.executions_flat SELECT * FROM giza.executions_flat;
+
+INSERT INTO agents.agent_identity_daily            SELECT * FROM giza.agent_identity_daily;
+INSERT INTO agents.agent_contracts_daily           SELECT * FROM giza.agent_contracts_daily;
+INSERT INTO agents.agent_users_daily               SELECT * FROM giza.agent_users_daily;
+INSERT INTO agents.strategies_daily                SELECT * FROM giza.strategies_daily;
+INSERT INTO agents.asset_daily                     SELECT * FROM giza.asset_daily;
+INSERT INTO agents.chain_total_tvl_daily           SELECT * FROM giza.chain_total_tvl_daily;
+INSERT INTO agents.chain_total_deployed_agents_daily SELECT * FROM giza.chain_total_deployed_agents_daily;
+INSERT INTO agents.deployed_agents_on_project_daily  SELECT * FROM giza.deployed_agents_on_project_daily;
+INSERT INTO agents.exec_stats_daily                SELECT * FROM giza.exec_stats_daily;
+INSERT INTO agents.returns_daily                   SELECT * FROM giza.returns_daily;
+INSERT INTO agents.riskfree_daily                  SELECT * FROM giza.riskfree_daily;
+INSERT INTO agents.loss_events                     SELECT * FROM giza.loss_events;
+INSERT INTO agents.tvl_ledger_daily                SELECT * FROM giza.tvl_ledger_daily;
+INSERT INTO agents.holdings_daily                  SELECT * FROM giza.holdings_daily;
+INSERT INTO agents.pools_depth_daily               SELECT * FROM giza.pools_depth_daily;
+INSERT INTO agents.sentiment_daily                 SELECT * FROM giza.sentiment_daily;
+
+/* ---------- Generic API view alias for convenience ---------- */
+CREATE OR REPLACE VIEW agents.v_agent_tx_history AS
+SELECT * FROM agents.v_tx_history;

--- a/db/giza-vaults/clickhouse/migrations/0010_backcompat_giza_views.sql
+++ b/db/giza-vaults/clickhouse/migrations/0010_backcompat_giza_views.sql
@@ -1,0 +1,7 @@
+/* Back-compat: alias to generic agents view; avoid renameat2 by using DROP + CREATE */
+CREATE DATABASE IF NOT EXISTS giza;
+
+DROP VIEW IF EXISTS giza.v_agent_tx_history;
+
+CREATE VIEW giza.v_agent_tx_history AS
+SELECT * FROM agents.v_tx_history;

--- a/db/giza-vaults/clickhouse/migrations/0100_agents_core.sql
+++ b/db/giza-vaults/clickhouse/migrations/0100_agents_core.sql
@@ -1,0 +1,125 @@
+/* ============================================================
+   Bond.Credit — Agents scoring core schema for ClickHouse
+   One big fact table (executions) + small helper tables + views
+   ============================================================ */
+
+CREATE DATABASE IF NOT EXISTS agents;
+CREATE DATABASE IF NOT EXISTS giza;
+
+/* --------- Helper/lookup tables (optional but useful) --------- */
+
+CREATE TABLE IF NOT EXISTS agents.agents
+(
+  agent_id       String,                         -- e.g. 'giza' or a UUID
+  agent_name     LowCardinality(String),         -- display name
+  model_type     LowCardinality(String) DEFAULT '',  -- optional (llm/tooling/etc)
+  owner_wallet   String DEFAULT '',
+  created_at     DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+ORDER BY (agent_id);
+
+CREATE TABLE IF NOT EXISTS agents.vaults
+(
+  chain_id       LowCardinality(String),
+  vault_address  String,
+  factory_address String DEFAULT '',
+  created_at     DateTime DEFAULT now(),
+  created_block  UInt64  DEFAULT 0
+)
+ENGINE = MergeTree
+ORDER BY (chain_id, vault_address);
+
+CREATE TABLE IF NOT EXISTS agents.wallets
+(
+  wallet_address String,
+  first_seen_at  DateTime DEFAULT now()
+)
+ENGINE = MergeTree
+ORDER BY (wallet_address);
+
+CREATE TABLE IF NOT EXISTS agents.user_vaults
+(
+  chain_id       LowCardinality(String),
+  vault_address  String,
+  wallet_address String,
+  role           LowCardinality(String) DEFAULT 'admin',  -- e.g. admin/viewer
+  linked_at      DateTime DEFAULT now(),
+  ingest_ts      DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id)
+ORDER BY (chain_id, vault_address, wallet_address);
+
+
+/* ---------------------- FACT: executions ----------------------
+   This is the “one big table” most queries will read.
+   Both AMA (ARMA) and subgraphs should insert into this.
+   Use consistent column names across sources.
+   ------------------------------------------------------------- */
+CREATE TABLE IF NOT EXISTS agents.executions
+(
+  /* identity */
+  chain_id            LowCardinality(String),
+  agent_name          LowCardinality(String),      -- 'giza' etc.
+  vault_address       String,
+
+  /* tx identity */
+  tx_hash             String,
+  log_index           UInt32  DEFAULT 0,           -- synthetic fallback if source lacks logIndex
+  block_number        UInt64  DEFAULT 0,
+  timestamp           DateTime DEFAULT now(),      -- execution time
+  block_timestamp     DateTime DEFAULT timestamp,
+
+  /* action & status */
+  action_type         LowCardinality(String),      -- deposit/withdraw/transfer
+  status              LowCardinality(String),      -- completed/failed/pending
+
+  /* asset */
+  asset_symbol        LowCardinality(String),
+  asset_address       String,
+  asset_decimals      UInt8   DEFAULT 18,
+  amount_asset        Decimal(38,18) DEFAULT 0,    -- normalized using decimals
+  amount_usd          Decimal(38,6)  DEFAULT 0,
+  price_usd           Decimal(38,6)  DEFAULT 0,
+
+  /* costs & pnl (optional) */
+  fee_usd             Decimal(38,6)  DEFAULT 0,
+  realized_pnl_usd    Decimal(38,6)  DEFAULT 0,
+
+  /* routing / protocol */
+  protocol            LowCardinality(String) DEFAULT '',
+  from_protocol       LowCardinality(String) DEFAULT '',
+  to_protocol         LowCardinality(String) DEFAULT '',
+  exchange            LowCardinality(String) DEFAULT '',
+
+  /* yield point-in-time */
+  apy_at_execution    Float64 DEFAULT 0,
+
+  /* provenance */
+  source              LowCardinality(String) DEFAULT 'unknown',  -- 'ama','subgraph','onchain'
+  ingest_ts           DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(timestamp))
+ORDER BY (chain_id, toDate(timestamp), vault_address, tx_hash, log_index)
+SETTINGS index_granularity = 8192;
+
+/* --------------------------- Views --------------------------- */
+
+CREATE OR REPLACE VIEW agents.v_tx_history AS
+SELECT
+  chain_id, agent_name, vault_address,
+  tx_hash, log_index, block_number,
+  timestamp, block_timestamp,
+  action_type, status,
+  asset_symbol, asset_address, asset_decimals,
+  amount_asset, amount_usd, price_usd, fee_usd, realized_pnl_usd,
+  protocol, from_protocol, to_protocol, exchange,
+  apy_at_execution,
+  source
+FROM agents.executions;
+
+/* Back-compat view for any legacy code that expects giza.* */
+CREATE OR REPLACE VIEW giza.v_agent_tx_history AS
+SELECT * FROM agents.v_tx_history;

--- a/db/giza-vaults/clickhouse/migrations/0110_alter_executions_add_metrics.sql
+++ b/db/giza-vaults/clickhouse/migrations/0110_alter_executions_add_metrics.sql
@@ -1,0 +1,29 @@
+/* Add point-in-time (at execution) metrics & running totals to the wide table.
+   These default to 0/NULL until your pipelines populate them. */
+
+ALTER TABLE agents.executions
+    ADD COLUMN IF NOT EXISTS roi_annualized_at_exec       Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS capital_efficiency_at_exec    Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS protocol_lindy_age_days       Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS sharpe_ratio_at_exec          Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS uptime_pct_30d                Float64 DEFAULT 0,
+
+    -- risk & scale
+    ADD COLUMN IF NOT EXISTS volatility_score_30d          Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS lifetime_tvl_log              Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS liquidity_depth_ratio         Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS tvl_growth_rate               Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS loss_events_weighted_90d      Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS risk_adjusted_tvl_usd         Decimal(38,6) DEFAULT 0,
+
+    -- qualitative / off-chain
+    ADD COLUMN IF NOT EXISTS community_sentiment_score_30d Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS criticism_severity_30d        Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS reputation_mentions_30d       UInt32  DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS earnings_consistency_90d      Float64 DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS asset_stability_score         Float64 DEFAULT 0,
+
+    -- convenient running sums (server-side or ETL maintained)
+    ADD COLUMN IF NOT EXISTS total_yield_usd_cum           Decimal(38,6) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS total_rewards_usd_cum         Decimal(38,6) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS fees_paid_usd_cum             Decimal(38,6) DEFAULT 0;

--- a/db/giza-vaults/clickhouse/migrations/0111_metrics_snapshots.sql
+++ b/db/giza-vaults/clickhouse/migrations/0111_metrics_snapshots.sql
@@ -1,0 +1,45 @@
+/* Windowed rollups per agent/vault (7d/30d/90d/all) */
+CREATE TABLE IF NOT EXISTS agents.metrics_snapshots
+(
+  chain_id      LowCardinality(String),
+  agent_name    LowCardinality(String),
+  vault_address String,
+  as_of_date    Date,
+  window        LowCardinality(String),  -- '7d' | '30d' | '90d' | 'all'
+
+  -- performance
+  success_rate                 Float64,
+  historical_roi_annualized    Float64,
+  performance_trend_30d        Float64,
+  performance_trend_90d        Float64,
+  capital_efficiency           Float64,
+  protocol_lindy_age_days      Float64,
+  sharpe_ratio                 Float64,
+  uptime_percentage            Float64,
+
+  -- risk & scale
+  volatility_score_30d         Float64,
+  lifetime_tvl_log             Float64,
+  liquidity_depth_ratio        Float64,
+  tvl_growth_rate              Float64,
+  loss_events_weighted_90d     Float64,
+  risk_adjusted_tvl_usd        Decimal(38,6),
+
+  -- qualitative / off-chain
+  community_sentiment_score_30d Float64,
+  criticism_severity_30d        Float64,
+  reputation_mentions_30d       UInt32,
+  earnings_consistency_90d      Float64,
+  asset_stability_score         Float64,
+
+  -- convenient totals/snapshots
+  total_yield_usd              Decimal(38,6),
+  total_rewards_usd            Decimal(38,6),
+  tvl_usd                      Decimal(38,6),
+
+  ingest_ts    DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY toYYYYMM(as_of_date)
+ORDER BY (chain_id, agent_name, vault_address, as_of_date, window)
+SETTINGS index_granularity = 8192;

--- a/db/giza-vaults/clickhouse/migrations/0112_views_metrics_latest.sql
+++ b/db/giza-vaults/clickhouse/migrations/0112_views_metrics_latest.sql
@@ -1,0 +1,33 @@
+/* Latest snapshot per agent/vault (pick most recent as_of_date for each group) */
+CREATE OR REPLACE VIEW agents.v_metrics_latest AS
+SELECT
+  chain_id, agent_name, vault_address,
+  argMax(success_rate,              as_of_date) AS success_rate,
+  argMax(historical_roi_annualized, as_of_date) AS historical_roi_annualized,
+  argMax(performance_trend_30d,     as_of_date) AS performance_trend_30d,
+  argMax(performance_trend_90d,     as_of_date) AS performance_trend_90d,
+  argMax(capital_efficiency,        as_of_date) AS capital_efficiency,
+  argMax(protocol_lindy_age_days,   as_of_date) AS protocol_lindy_age_days,
+  argMax(sharpe_ratio,              as_of_date) AS sharpe_ratio,
+  argMax(uptime_percentage,         as_of_date) AS uptime_percentage,
+
+  argMax(volatility_score_30d,      as_of_date) AS volatility_score_30d,
+  argMax(lifetime_tvl_log,          as_of_date) AS lifetime_tvl_log,
+  argMax(liquidity_depth_ratio,     as_of_date) AS liquidity_depth_ratio,
+  argMax(tvl_growth_rate,           as_of_date) AS tvl_growth_rate,
+  argMax(loss_events_weighted_90d,  as_of_date) AS loss_events_weighted_90d,
+  argMax(risk_adjusted_tvl_usd,     as_of_date) AS risk_adjusted_tvl_usd,
+
+  argMax(community_sentiment_score_30d, as_of_date) AS community_sentiment_score_30d,
+  argMax(criticism_severity_30d,        as_of_date) AS criticism_severity_30d,
+  argMax(reputation_mentions_30d,       as_of_date) AS reputation_mentions_30d,
+  argMax(earnings_consistency_90d,      as_of_date) AS earnings_consistency_90d,
+  argMax(asset_stability_score,         as_of_date) AS asset_stability_score,
+
+  argMax(total_yield_usd,           as_of_date) AS total_yield_usd,
+  argMax(total_rewards_usd,         as_of_date) AS total_rewards_usd,
+  argMax(tvl_usd,                   as_of_date) AS tvl_usd,
+
+  max(as_of_date) AS as_of_date_latest
+FROM agents.metrics_snapshots
+GROUP BY chain_id, agent_name, vault_address;

--- a/db/giza-vaults/clickhouse/migrations/quick_fix_schema.sql
+++ b/db/giza-vaults/clickhouse/migrations/quick_fix_schema.sql
@@ -1,0 +1,56 @@
+/* ---------- Minimal schema for demo ---------- */
+CREATE DATABASE IF NOT EXISTS agents;
+CREATE DATABASE IF NOT EXISTS giza;
+
+CREATE TABLE IF NOT EXISTS agents.executions
+(
+  chain_id LowCardinality(String),
+  agent_name LowCardinality(String),
+  vault_address String,
+
+  tx_hash String,
+  log_index UInt16 DEFAULT 0,
+  block_number UInt64 DEFAULT 0,
+  timestamp DateTime DEFAULT now(),
+  block_timestamp DateTime DEFAULT timestamp,
+
+  action_type LowCardinality(String),
+  status LowCardinality(String),
+
+  asset_symbol LowCardinality(String),
+  asset_address String,
+  asset_decimals UInt8 DEFAULT 18,
+  amount_asset Decimal(38,18) DEFAULT 0,
+  amount_usd   Decimal(38,6)  DEFAULT 0,
+  price_usd    Decimal(38,6)  DEFAULT 0,
+  fee_usd      Decimal(38,6)  DEFAULT 0,
+  realized_pnl_usd Decimal(38,6) DEFAULT 0,
+
+  protocol LowCardinality(String),
+  from_protocol LowCardinality(String),
+  to_protocol LowCardinality(String),
+  exchange LowCardinality(String),
+
+  apy_at_execution Float64 DEFAULT 0,
+  ingest_ts DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(ingest_ts)
+PARTITION BY (chain_id, toYYYYMM(timestamp))
+ORDER BY (chain_id, toDate(timestamp), vault_address, tx_hash, log_index);
+
+/* View the app/API will query */
+CREATE OR REPLACE VIEW agents.v_tx_history AS
+SELECT
+  chain_id, agent_name, vault_address,
+  tx_hash, log_index, block_number,
+  timestamp, block_timestamp,
+  action_type, status,
+  asset_symbol, asset_address, asset_decimals,
+  amount_asset, amount_usd, price_usd, fee_usd, realized_pnl_usd,
+  protocol, from_protocol, to_protocol, exchange,
+  apy_at_execution
+FROM agents.executions;
+
+/* Back-compat alias (so old code using giza.v_agent_tx_history still works) */
+CREATE OR REPLACE VIEW giza.v_agent_tx_history AS
+SELECT * FROM agents.v_tx_history;

--- a/db/giza-vaults/clickhouse/package.json
+++ b/db/giza-vaults/clickhouse/package.json
@@ -1,0 +1,7 @@
+{
+"type": "module",
+"dependencies": {
+"@clickhouse/client": "^0.2.7",
+"dotenv": "^16.4.5"
+}
+}

--- a/db/giza-vaults/clickhouse/scripts/ch_migrate.ps1
+++ b/db/giza-vaults/clickhouse/scripts/ch_migrate.ps1
@@ -1,0 +1,27 @@
+Param(
+[string]$ServiceName = "giza_clickhouse",
+[string]$Db = "giza",
+[string]$User = $env:CH_USER,
+[string]$Password = $env:CH_PASSWORD
+)
+
+
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
+$root = Resolve-Path "$here/.."
+$migrations = Join-Path $root "migrations"
+
+
+$files = @(
+"0001_tables.sql",
+"0002_views.sql",
+"0003_access.sql"
+)
+
+
+foreach ($f in $files) {
+$src = Join-Path $migrations $f
+Write-Host "Applying $f ..."
+docker cp $src "$ServiceName:/tmp/$f" | Out-Null
+docker exec -e CLICKHOUSE_PASSWORD=$Password -it $ServiceName bash -lc "clickhouse-client -u $User -d $Db --queries-file=/tmp/$f"
+}
+Write-Host "Done."

--- a/db/giza-vaults/clickhouse/scripts/ch_smoke.ps1
+++ b/db/giza-vaults/clickhouse/scripts/ch_smoke.ps1
@@ -1,0 +1,15 @@
+Param(
+[string]$ServiceName = "giza_clickhouse",
+[string]$Db = "giza",
+[string]$User = $env:CH_USER,
+[string]$Password = $env:CH_PASSWORD
+)
+
+
+docker exec -e CLICKHOUSE_PASSWORD=$Password -it $ServiceName bash -lc @"
+clickhouse-client -u $User -d $Db -q """
+SELECT database, name, engine
+FROM system.tables
+WHERE database = '$Db'
+ORDER BY name;"""
+"@

--- a/db/giza-vaults/clickhouse/scripts/ingest_ama_wallet.js
+++ b/db/giza-vaults/clickhouse/scripts/ingest_ama_wallet.js
@@ -1,0 +1,328 @@
+import 'dotenv/config';
+import { createClient } from '@clickhouse/client';
+
+/* =========================
+   ENV (safe local defaults)
+   ========================= */
+const CH_HOST = process.env.CH_HOST || 'localhost';
+const CH_PORT = process.env.CH_HTTP_PORT || '8123';
+const CH_DB   = process.env.CH_DB || 'agents';
+const CH_USER = process.env.CH_USER || 'giza';
+const CH_PASS = process.env.CH_PASSWORD || 'giza_pw_change_me';
+
+const AMA_API_BASE = (process.env.AMA_API_BASE || 'https://api.arma.xyz/api/v1').replace(/\/+$/, ''); // strip trailing slash
+
+/* =========================
+   CLI ARGS (support --k=v and --k v)
+   ========================= */
+const argv = {};
+const parts = process.argv.slice(2);
+for (let i = 0; i < parts.length; i++) {
+  const s = parts[i];
+  if (!s.startsWith('--')) continue;
+  if (s.includes('=')) {
+    const [k, v] = s.slice(2).split(/=(.*)/);
+    argv[k] = v;
+  } else {
+    const k = s.slice(2);
+    const v = (i + 1 < parts.length && !parts[i + 1].startsWith('--')) ? parts[++i] : true;
+    argv[k] = v;
+  }
+}
+
+const chain_id = String(argv.chain ?? argv.c ?? '8453'); // Base mainnet default
+const vault_address = String(argv.vault ?? argv.v ?? '');
+const agent_name = String(argv.agent ?? 'giza');
+const pages = Number(argv.pages ?? 1);
+const limit = Number(argv.limit ?? 100);
+
+// minimal validation (avoid 422s)
+if (!/^0x[a-fA-F0-9]{40}$/.test(vault_address)) {
+  console.error(`Invalid --vault address: "${vault_address}"`);
+  process.exit(1);
+}
+if (!/^(8453|-1|84532|1|11155111)$/.test(chain_id)) {
+  console.error(`Invalid --chain value: "${chain_id}" (expected one of 8453, -1, 84532, 1, 11155111)`);
+  process.exit(1);
+}
+
+/* =========================
+   ClickHouse client
+   ========================= */
+const ch = createClient({
+  url: `http://${CH_HOST}:${CH_PORT}`,
+  database: CH_DB,
+  username: CH_USER,
+  password: CH_PASS,
+});
+
+async function insertExecutions(rows) {
+  if (!rows || rows.length === 0) return;
+  await ch.insert({
+    table: 'agents.executions',
+    values: rows,
+    format: 'JSONEachRow',
+  });
+  console.log(`Inserted ${rows.length} rows -> agents.executions`);
+}
+
+/* =========================
+   Helpers
+   ========================= */
+const toLower0x = (v) => (v ? String(v).toLowerCase() : '');
+
+function toISODateTime(ts) {
+  // ClickHouse DateTime expects 'YYYY-MM-DD HH:MM:SS'
+  const toSQL = (d) => d.toISOString().replace('T', ' ').slice(0, 19);
+  if (!ts) return toSQL(new Date());
+  if (typeof ts === 'number') return toSQL(new Date(ts * 1000));
+  const s = String(ts);
+  if (/^\d+$/.test(s)) return toSQL(new Date(Number(s) * 1000));
+  return s.replace('T', ' ').slice(0, 19);
+}
+
+function toDecimalString(x) {
+  if (x === null || x === undefined) return '0';
+  return String(x);
+}
+
+function guessActionType(tx, vault) {
+  // Prefer AMA-native "action" if present
+  const a = String(tx.action ?? '').toLowerCase();
+  if (a === 'deposit' || a === 'withdraw' || a === 'transfer') return a;
+
+  // Fallback heuristic
+  const from = toLower0x(tx.from);
+  const to   = toLower0x(tx.to);
+  const v    = toLower0x(vault);
+  if (to && v && to === v) return 'deposit';
+  if (from && v && from === v) return 'withdraw';
+  const method = (tx.method || tx.action || '').toLowerCase();
+  if (method.includes('swap') || method.includes('trade')) return 'transfer';
+  return 'transfer';
+}
+
+function mapStatus(tx) {
+  // AMA shows e.g. "approved" → treat as completed
+  const s = (tx.status || tx.tx_status || '').toString().toLowerCase();
+  if (['success', 'succeeded', 'completed', 'approved', '1', 'true'].includes(s)) return 'completed';
+  if (['failed', '0', 'false', 'rejected'].includes(s)) return 'failed';
+  return 'completed';
+}
+
+/*  Stablecoin decimal overrides (by SYMBOL and by ADDRESS).
+    We DO NOT change asset_symbol; only fix decimals for normalization. */
+
+// Known USDC on Base
+const BASE_USDC_ADDR = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+
+const STABLE_DECIMALS_BY_SYMBOL = new Map([
+  ['usdc', 6],
+  ['usdbc', 6],   // legacy bridged symbol on Base
+  ['usdc.e', 6],
+]);
+
+const DECIMALS_BY_ADDRESS = new Map([
+  [BASE_USDC_ADDR, 6],
+]);
+
+function normalizeAsset(tx) {
+  // Prefer AMA-native token fields. DO NOT override symbol text.
+  const symbolRaw =
+    tx.tokenSymbol || tx.assetSymbol || tx.symbol ||
+    (tx.currency && tx.currency.symbol) || '';
+  const symbol = String(symbolRaw || 'UNKNOWN');
+
+  // Prefer token_type for address when present (as in the AMA sample)
+  const addressRaw =
+    tx.token_type || tx.tokenAddress || tx.assetAddress || tx.contractAddress ||
+    (tx.currency && tx.currency.address) || '';
+  const address = toLower0x(addressRaw);
+
+  // decimals from API if present
+  let decimals =
+    tx.tokenDecimals ?? tx.assetDecimals ?? tx.decimals ??
+    (tx.currency && tx.currency.decimals);
+
+  decimals = Number.isFinite(Number(decimals)) ? Number(decimals) : undefined;
+
+  // If decimals missing: try address map, then symbol map
+  if (decimals == null && address) {
+    const d = DECIMALS_BY_ADDRESS.get(address);
+    if (d != null) decimals = d;
+  }
+  if (decimals == null) {
+    const key = symbol.toLowerCase();
+    if (STABLE_DECIMALS_BY_SYMBOL.has(key)) decimals = STABLE_DECIMALS_BY_SYMBOL.get(key);
+  }
+  if (decimals == null) decimals = 18; // final fallback
+
+  // amount: AMA uses integer "amount" (e.g., 11028875 for USDC 6dp)
+  const raw = tx.value ?? tx.amount ?? tx.quantity ?? 0;
+  let amountHuman = '0';
+  try {
+    const rawStr = String(raw);
+    if (/^\d+$/.test(rawStr)) {
+      const pad = rawStr.padStart(decimals + 1, '0');
+      amountHuman = pad.slice(0, -decimals) + (decimals ? '.' + pad.slice(-decimals) : '');
+    } else {
+      amountHuman = rawStr; // already decimal-like
+    }
+  } catch {
+    amountHuman = '0';
+  }
+
+  return {
+    symbol,
+    address,
+    decimals,
+    amountHuman: toDecimalString(amountHuman),
+  };
+}
+
+/* APY mapper: map apr/apy fields to apy_at_execution (percentage) */
+function mapApy(tx) {
+  const candidates = [
+    ['apy', 1],
+    ['apr', 1],                 // AMA sample uses "apr" as a percent number
+    ['apyAtExecution', 1],
+    ['aprAtExecution', 1],
+    ['apy_at_execution', 1],
+    ['apr_at_execution', 1],
+    ['yield', 1],
+    ['apyPercent', 1],
+    ['aprPercent', 1],
+    ['apyBps', 0.01],           // bps → %
+    ['aprBps', 0.01],
+  ];
+  for (const [k, scale] of candidates) {
+    const v = tx?.[k];
+    if (v === undefined || v === null || v === '') continue;
+    const num = Number(v);
+    if (!Number.isFinite(num)) continue;
+    return num * scale;
+  }
+  return 0;
+}
+
+/* =========================
+   Mapper: AMA tx → agents.executions row
+   Uses AMA-native fields first; seq keeps rows distinct if log index is absent.
+   ========================= */
+function amaTxToExecRow(tx, { chain_id, agent_name, vault_address, seq = 0 }) {
+  const { symbol, address, decimals, amountHuman } = normalizeAsset(tx);
+
+  const action_type = guessActionType(tx, vault_address);
+  const status = mapStatus(tx);
+
+  const tx_hash =
+    tx.transaction_hash || tx.transactionHash || tx.hash || tx.tx_hash || '';
+
+  // Prefer real log index; otherwise use our synthetic seq to keep rows distinct
+  const log_index = Number(
+    tx.logIndex ?? tx.log_index ?? tx.eventIndex ?? tx.index ?? seq ?? 0
+  );
+
+  const block_number = Number(tx.blockNumber ?? tx.block_number ?? 0);
+
+  // Prefer AMA "date" (ISO Z) if present, else blockTimestamp/timestamp
+  const timestamp = toISODateTime(tx.date ?? tx.blockTimestamp ?? tx.timestamp);
+
+  const apy_at_execution = mapApy(tx);
+
+  return {
+    chain_id: String(chain_id),
+    agent_name: String(agent_name),
+    vault_address: toLower0x(vault_address),
+
+    tx_hash,
+    log_index,
+    block_number,
+    timestamp,
+    block_timestamp: timestamp,
+
+    action_type,
+    status,
+
+    asset_symbol: symbol,            // we do not change the symbol text
+    asset_address: address,
+    asset_decimals: Number(decimals) || 18,
+    amount_asset: amountHuman,       // normalized using decimals (USDC → 6)
+    amount_usd: '0',                 // pricing to be added later
+    price_usd: '0',
+    fee_usd: '0',
+    realized_pnl_usd: '0',
+
+    protocol: tx.protocol || '',
+    from_protocol: tx.from_protocol || '',
+    to_protocol: tx.to_protocol || '',
+    exchange: tx.exchange || '',
+
+    apy_at_execution,                // % value if present, else 0
+    // ingest_ts comes from server default
+  };
+}
+
+/* =========================
+   AMA fetcher (robust envelope handling)
+   ========================= */
+async function fetchAmaPage({ chain_id, vault, page, limit }) {
+  const url = `${AMA_API_BASE}/${chain_id}/wallets/${vault}/transactions?page=${page}&limit=${limit}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`AMA API ${res.status}: ${body}`);
+  }
+  const data = await res.json();
+
+  let items = [];
+  if (Array.isArray(data)) items = data;
+  else if (Array.isArray(data.items)) items = data.items;
+  else if (Array.isArray(data.results)) items = data.results;
+  else if (Array.isArray(data.transactions)) items = data.transactions; // AMA sample
+  else if (data.data) {
+    if (Array.isArray(data.data)) items = data.data;
+    else if (Array.isArray(data.data.items)) items = data.data.items;
+    else if (Array.isArray(data.data.results)) items = data.data.results;
+    else if (Array.isArray(data.data.transactions)) items = data.data.transactions;
+  }
+
+  if (!items.length) {
+    const keys = Object.keys(data || {});
+    const dataKeys = data?.data && !Array.isArray(data.data) ? Object.keys(data.data) : null;
+    console.log(
+      `AMA page ${page}: 0 items. Top-level keys: ${JSON.stringify(keys)}` +
+      (dataKeys ? `; data.keys: ${JSON.stringify(dataKeys)}` : '')
+    );
+  }
+  return items;
+}
+
+/* =========================
+   Main
+   ========================= */
+async function run() {
+  console.log(`Source: ${AMA_API_BASE}/${chain_id}/wallets/${vault_address}/transactions`);
+  let total = 0;
+
+  for (let p = 1; p <= pages; p++) {
+    const items = await fetchAmaPage({ chain_id, vault: vault_address, page: p, limit });
+    if (!items.length) {
+      console.log(`Page ${p} returned 0 items. Stopping.`);
+      break;
+    }
+    const baseSeq = (p - 1) * limit; // keeps synthetic log_index unique across pages
+    const rows = items.map((tx, i) =>
+      amaTxToExecRow(tx, { chain_id, agent_name, vault_address, seq: baseSeq + i })
+    );
+    await insertExecutions(rows);
+    total += rows.length;
+  }
+
+  console.log(`Done. Inserted total: ${total}`);
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/db/giza-vaults/clickhouse/scripts/ingest_ama_wallet.js
+++ b/db/giza-vaults/clickhouse/scripts/ingest_ama_wallet.js
@@ -258,7 +258,8 @@ function amaTxToExecRow(tx, { chain_id, agent_name, vault_address, seq = 0 }) {
     to_protocol: tx.to_protocol || '',
     exchange: tx.exchange || '',
 
-    apy_at_execution,                // % value if present, else 0
+    apy_at_execution, 
+    source: 'ama',               // % value if present, else 0
     // ingest_ts comes from server default
   };
 }

--- a/db/giza-vaults/clickhouse/scripts/ingest_ch_sample.js
+++ b/db/giza-vaults/clickhouse/scripts/ingest_ch_sample.js
@@ -1,0 +1,63 @@
+// Minimal demo: insert 2 executions and a mapping
+// Usage: node scripts/ingest_ch_sample.js
+import { createClient } from '@clickhouse/client'
+import fs from 'node:fs'
+import path from 'node:path'
+import 'dotenv/config'
+
+
+const host = process.env.CH_HOST || 'localhost'
+const port = process.env.CH_HTTP_PORT || '8123'
+const db = process.env.CH_DB || 'giza'
+const user = process.env.CH_USER || 'giza'
+const password = process.env.CH_PASSWORD || 'giza_pw_change_me'
+
+
+const client = createClient({
+host: `http://${host}:${port}`,
+database: db,
+username: user,
+password,
+})
+
+
+async function main(){
+// map a user to a vault
+await client.command({
+query: `INSERT INTO giza.user_vaults (chain_id, vault_address, wallet_address, linked_at) VALUES`,
+values: [
+['base', '0xVaultA', '0xAdmin1', new Date()],
+],
+clickhouse_settings: { async_insert: 1 }
+})
+
+
+// insert 2 executions (ReplacingMergeTree will dedup per ORDER BY key keeping latest by ingest_ts)
+const now = new Date()
+const rows = [
+['base','0xVaultA','0xTx1',0,123n, now,'deposit','completed','USDC','0xA0b86991',6,'100.000000000000000000','100.000000','AaveV3','',null,0.05],
+['base','0xVaultA','0xTx2',0,124n, now,'withdraw','failed','USDC','0xA0b86991',6,'50.000000000000000000','50.000000','AaveV3','',null,0.00]
+]
+await client.insert({
+table: 'giza.executions',
+values: rows,
+format: 'JSONEachRow',
+// map to named columns
+columns: [
+'chain_id','vault_address','tx_hash','log_index','block_number','timestamp','action_type','status',
+'asset_symbol','asset_address','asset_decimals','amount_asset','amount_usd','protocol','from_protocol','to_protocol','apy_at_execution'
+]
+})
+
+
+// read back from the API view
+const rs = await client.query({
+query: `SELECT chain_id, vault_address, tx_hash, action_type, status, amount_usd, timestamp FROM giza.v_agent_tx_history ORDER BY timestamp DESC LIMIT 10`,
+format: 'JSONEachRow',
+})
+const data = await rs.json()
+console.log(data)
+}
+
+
+main().then(()=> process.exit(0)).catch(e=>{ console.error(e); process.exit(1) })

--- a/db/giza-vaults/docker-compose.yml
+++ b/db/giza-vaults/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: postgres:16
+    container_name: giza_db
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "${PGPORT}:5432"
+    volumes:
+      - ./_pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: giza_pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: adminadmin
+    ports:
+      - "8081:80"
+    depends_on:
+      - db
+    volumes:
+      - ./_pgadmin:/var/lib/pgadmin

--- a/db/giza-vaults/docs/er.md
+++ b/db/giza-vaults/docs/er.md
@@ -1,0 +1,47 @@
+# ER Diagram — Giza Agent Vaults DB
+
+```mermaid
+erDiagram
+  VAULTS ||--o{ USER_VAULTS : has
+  USERS  ||--o{ USER_VAULTS : has
+  VAULTS ||--o{ EXECUTIONS  : records
+
+  VAULTS {
+    bigint vault_id PK
+    text   chain_id
+    text   factory_address
+    text   vault_address
+    timestamptz created_at
+    bigint created_block
+  }
+
+  USERS {
+    bigint user_id PK
+    text   wallet_address UK
+    timestamptz first_seen_at
+  }
+
+  USER_VAULTS {
+    bigint id PK
+    bigint vault_id FK
+    bigint user_id FK
+    timestamptz linked_at
+  }
+
+  EXECUTIONS {
+    bigint execution_id PK
+    bigint vault_id FK
+    text   action_type
+    text   status
+    text   asset_symbol
+    text   asset_address
+    numeric amount_asset
+    int     asset_decimals
+    numeric amount_usd
+    text   from_protocol
+    text   to_protocol
+    numeric apy_at_execution
+    text   tx_hash
+    timestamptz timestamp
+    bigint block_number
+  }

--- a/db/giza-vaults/migrations/0001_init.sql
+++ b/db/giza-vaults/migrations/0001_init.sql
@@ -1,0 +1,62 @@
+DO $$ BEGIN
+  CREATE TYPE action_type_enum AS ENUM ('deposit','withdraw','transfer');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE status_enum AS ENUM ('pending','completed','failed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS vaults (
+  vault_id         BIGSERIAL PRIMARY KEY,
+  chain_id         TEXT NOT NULL,
+  factory_address  TEXT NOT NULL,
+  vault_address    TEXT NOT NULL,
+  created_at       TIMESTAMPTZ NOT NULL,
+  created_block    BIGINT,
+  CONSTRAINT uq_vault UNIQUE (chain_id, vault_address)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  user_id        BIGSERIAL PRIMARY KEY,
+  wallet_address TEXT NOT NULL UNIQUE,
+  first_seen_at  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_vaults (
+  id         BIGSERIAL PRIMARY KEY,
+  vault_id   BIGINT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE,
+  user_id    BIGINT NOT NULL REFERENCES users(user_id)  ON DELETE CASCADE,
+  linked_at  TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT uq_user_vault UNIQUE (vault_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS executions (
+  execution_id       BIGSERIAL PRIMARY KEY,
+  vault_id           BIGINT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE,
+  action_type        action_type_enum NOT NULL,
+  status             status_enum NOT NULL,
+  asset_symbol       TEXT,
+  asset_address      TEXT,
+  asset_decimals     INT,
+  amount_asset       NUMERIC(78, 0),          -- raw units (no decimals)
+  amount_usd         NUMERIC(38, 10),         -- normalized USD value
+  from_protocol      TEXT,
+  to_protocol        TEXT,
+  apy_at_execution   NUMERIC(10, 6),
+  tx_hash            TEXT NOT NULL,
+  timestamp          TIMESTAMPTZ NOT NULL,
+  block_number       BIGINT,
+  CONSTRAINT uq_tx UNIQUE (tx_hash, vault_id),
+  CONSTRAINT ck_transfer_requires_to CHECK (
+    (action_type <> 'transfer') OR (to_protocol IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS ix_vaults_factory ON vaults(factory_address);
+CREATE INDEX IF NOT EXISTS ix_vaults_chain_addr ON vaults(chain_id, vault_address);
+CREATE INDEX IF NOT EXISTS ix_uv_user ON user_vaults(user_id);
+CREATE INDEX IF NOT EXISTS ix_uv_vault ON user_vaults(vault_id);
+CREATE INDEX IF NOT EXISTS ix_exec_vault_time ON executions(vault_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS ix_exec_status ON executions(status);
+CREATE INDEX IF NOT EXISTS ix_exec_protocol ON executions((COALESCE(to_protocol, from_protocol)));
+CREATE INDEX IF NOT EXISTS ix_exec_asset ON executions(asset_symbol);

--- a/db/giza-vaults/migrations/0002_views.sql
+++ b/db/giza-vaults/migrations/0002_views.sql
@@ -1,0 +1,35 @@
+CREATE OR REPLACE VIEW v_vaults_from_factory AS
+SELECT chain_id, factory_address, vault_address, created_at, created_block, vault_id
+FROM vaults;
+
+CREATE OR REPLACE VIEW v_vault_user_associations AS
+SELECT v.vault_id, v.chain_id, v.vault_address, u.user_id, u.wallet_address, uv.linked_at
+FROM user_vaults uv
+JOIN users u  ON u.user_id  = uv.user_id
+JOIN vaults v ON v.vault_id = uv.vault_id;
+
+CREATE OR REPLACE VIEW v_execution_history AS
+SELECT
+  e.execution_id, e.vault_id, v.chain_id, v.vault_address,
+  e.action_type, e.status,
+  e.asset_symbol, e.asset_address, e.asset_decimals,
+  e.amount_asset, e.amount_usd,
+  COALESCE(e.to_protocol, e.from_protocol) AS protocol,
+  e.apy_at_execution, e.tx_hash, e.timestamp, e.block_number
+FROM executions e
+JOIN vaults v ON v.vault_id = e.vault_id;
+
+CREATE OR REPLACE VIEW v_agent_tx_history AS
+SELECT
+  v.chain_id,
+  v.vault_address,
+  e.tx_hash,
+  e.action_type,
+  e.status,
+  e.asset_symbol,
+  e.amount_usd,
+  COALESCE(e.to_protocol, e.from_protocol) AS protocol,
+  e.apy_at_execution,
+  e.timestamp
+FROM executions e
+JOIN vaults v ON v.vault_id = e.vault_id;

--- a/db/giza-vaults/migrations/0003_upserts.sql
+++ b/db/giza-vaults/migrations/0003_upserts.sql
@@ -1,0 +1,70 @@
+CREATE OR REPLACE FUNCTION upsert_vault(
+  p_chain_id TEXT,
+  p_factory_address TEXT,
+  p_vault_address TEXT,
+  p_created_at TIMESTAMPTZ,
+  p_created_block BIGINT
+) RETURNS BIGINT AS $$
+DECLARE vid BIGINT;
+BEGIN
+  INSERT INTO vaults(chain_id, factory_address, vault_address, created_at, created_block)
+  VALUES (p_chain_id, p_factory_address, p_vault_address, p_created_at, p_created_block)
+  ON CONFLICT (chain_id, vault_address)
+  DO UPDATE SET factory_address = EXCLUDED.factory_address,
+                created_at = LEAST(vaults.created_at, EXCLUDED.created_at),
+                created_block = COALESCE(vaults.created_block, EXCLUDED.created_block)
+  RETURNING vault_id INTO vid;
+  RETURN vid;
+END; $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION upsert_user(p_wallet TEXT) RETURNS BIGINT AS $$
+DECLARE uid BIGINT;
+BEGIN
+  INSERT INTO users(wallet_address) VALUES (p_wallet)
+  ON CONFLICT (wallet_address) DO NOTHING;
+  SELECT user_id INTO uid FROM users WHERE wallet_address = p_wallet;
+  RETURN uid;
+END; $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION link_user_vault(p_vault_id BIGINT, p_user_id BIGINT) RETURNS VOID AS $$
+BEGIN
+  INSERT INTO user_vaults(vault_id, user_id) VALUES (p_vault_id, p_user_id)
+  ON CONFLICT (vault_id, user_id) DO NOTHING;
+END; $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION upsert_execution(
+  p_vault_id BIGINT,
+  p_action action_type_enum,
+  p_status status_enum,
+  p_asset_symbol TEXT,
+  p_asset_address TEXT,
+  p_asset_decimals INT,
+  p_amount_asset NUMERIC,
+  p_amount_usd NUMERIC,
+  p_from_protocol TEXT,
+  p_to_protocol TEXT,
+  p_apy NUMERIC,
+  p_tx_hash TEXT,
+  p_timestamp TIMESTAMPTZ,
+  p_block BIGINT
+) RETURNS BIGINT AS $$
+DECLARE eid BIGINT;
+BEGIN
+  INSERT INTO executions(
+    vault_id, action_type, status, asset_symbol, asset_address, asset_decimals,
+    amount_asset, amount_usd, from_protocol, to_protocol, apy_at_execution,
+    tx_hash, timestamp, block_number
+  ) VALUES (
+    p_vault_id, p_action, p_status, p_asset_symbol, p_asset_address, p_asset_decimals,
+    p_amount_asset, p_amount_usd, p_from_protocol, p_to_protocol, p_apy,
+    p_tx_hash, p_timestamp, p_block
+  )
+  ON CONFLICT (tx_hash, vault_id)
+  DO UPDATE SET status = EXCLUDED.status,
+                amount_usd = COALESCE(EXCLUDED.amount_usd, executions.amount_usd),
+                apy_at_execution = COALESCE(EXCLUDED.apy_at_execution, executions.apy_at_execution),
+                block_number = COALESCE(EXCLUDED.block_number, executions.block_number),
+                timestamp = LEAST(executions.timestamp, EXCLUDED.timestamp)
+  RETURNING execution_id INTO eid;
+  RETURN eid;
+END; $$ LANGUAGE plpgsql;

--- a/db/giza-vaults/migrations/0004_roles.sql
+++ b/db/giza-vaults/migrations/0004_roles.sql
@@ -1,0 +1,7 @@
+DO $$ BEGIN CREATE ROLE etl_writer LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE ROLE api_reader LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+GRANT USAGE ON SCHEMA public TO etl_writer, api_reader;
+GRANT SELECT, INSERT, UPDATE ON vaults, users, user_vaults, executions TO etl_writer;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO etl_writer;
+GRANT SELECT ON v_vaults_from_factory, v_vault_user_associations, v_execution_history, v_agent_tx_history TO api_reader;

--- a/db/giza-vaults/package-lock.json
+++ b/db/giza-vaults/package-lock.json
@@ -1,0 +1,254 @@
+{
+  "name": "giza-vaults-db",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "giza-vaults-db",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^3.3.2",
+        "pg": "^8.16.3"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/db/giza-vaults/package.json
+++ b/db/giza-vaults/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "giza-vaults-db",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "node-fetch": "^3.3.2",
+    "pg": "^8.16.3"
+  }
+}

--- a/db/giza-vaults/postgres/.gitignore
+++ b/db/giza-vaults/postgres/.gitignore
@@ -1,0 +1,5 @@
+.env
+.env.*
+_ch_data/
+ops/CH_SET_PASSWORDS.sql
+node_modules/

--- a/db/giza-vaults/postgres/README.md
+++ b/db/giza-vaults/postgres/README.md
@@ -1,0 +1,64 @@
+See the ER diagram in [docs/er.md](docs/er.md).
+
+# Giza Agent Vaults DB
+
+Normalized Postgres schema and views to store and query: Factory → Vaults → User mapping → Execution history. Powers `/agent/{chain_id}/giza/{vault_address}/tx_history`.
+
+## Structure
+
+* `migrations/` – schema as code (**run in order**: `0001_init.sql` → `0003_upserts.sql` → `0002_views.sql` → `0004_roles.sql`)
+* `seeds/` – sample data (optional smoke test; uses the upsert functions)
+* `scripts/` – ingest/API helpers (to be finalized with subgraph + Giza API)
+* `docs/er.md` – ER diagram (Mermaid)
+* `ops/SET_ROLE_PASSWORDS.sql.example` – template to set per-environment role passwords (copy, fill, run; **do not commit** the filled copy)
+
+## Endpoints supported (via SQL views)
+
+* `/agent/{chain_id}/giza/{vault_address}/tx_history` ⇒ `v_agent_tx_history`
+
+**Use this query in the route handler:**
+
+```sql
+SELECT *
+FROM v_agent_tx_history
+WHERE chain_id = $1 AND vault_address = $2
+ORDER BY timestamp DESC
+LIMIT $3 OFFSET $4;
+```
+
+## Quick start (local)
+
+```bash
+# 1) copy env
+cp .env.example .env   # set POSTGRES_PASSWORD etc.
+
+# 2) run DB + pgAdmin (Postgres on localhost:5433, pgAdmin on http://localhost:8081)
+docker compose up -d
+
+# 3) apply migrations (order matters)
+#    0001_init.sql -> 0003_upserts.sql -> 0002_views.sql -> 0004_roles.sql
+#    (via pgAdmin Query Tool or CLI: docker cp + psql -f)
+
+# 4) (optional) set app role passwords
+#    copy ops/SET_ROLE_PASSWORDS.sql.example -> ops/SET_ROLE_PASSWORDS.sql
+#    fill passwords and run it once (do NOT commit the filled file)
+
+# 5) (optional) seed & test
+#    run seeds/seed.sql, then:
+#    SELECT * FROM v_agent_tx_history ORDER BY timestamp DESC LIMIT 20;
+```
+
+## Which credentials to use
+
+* **Migrations / local admin:** `giza / <POSTGRES_PASSWORD>`
+* **Ingest service (pipeline):** `etl_writer / <ETL_PASSWORD>`
+* **Read API / backend:** `api_reader / <API_PASSWORD>`
+
+> If a service runs inside the same Docker network as Postgres, use `host=db` and `port=5432`.
+> From your host machine, use `host=localhost` (or `127.0.0.1`) and `port=5433`.
+
+## Notes
+
+* Vaults are unique on `(chain_id, vault_address)`.
+* Executions are unique on `(tx_hash, vault_id)`; status can be updated safely (idempotent upserts).
+* Views give a stable API shape while we evolve internals.

--- a/db/giza-vaults/postgres/docker-compose.yml
+++ b/db/giza-vaults/postgres/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  db:
+    image: postgres:16
+    container_name: giza_db
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "${PGPORT}:5432"
+    volumes:
+      - ./_pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: giza_pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: adminadmin
+    ports:
+      - "8081:80"
+    depends_on:
+      - db
+    volumes:
+      - ./_pgadmin:/var/lib/pgadmin

--- a/db/giza-vaults/postgres/docs/er.md
+++ b/db/giza-vaults/postgres/docs/er.md
@@ -1,0 +1,47 @@
+# ER Diagram — Giza Agent Vaults DB
+
+```mermaid
+erDiagram
+  VAULTS ||--o{ USER_VAULTS : has
+  USERS  ||--o{ USER_VAULTS : has
+  VAULTS ||--o{ EXECUTIONS  : records
+
+  VAULTS {
+    bigint vault_id PK
+    text   chain_id
+    text   factory_address
+    text   vault_address
+    timestamptz created_at
+    bigint created_block
+  }
+
+  USERS {
+    bigint user_id PK
+    text   wallet_address UK
+    timestamptz first_seen_at
+  }
+
+  USER_VAULTS {
+    bigint id PK
+    bigint vault_id FK
+    bigint user_id FK
+    timestamptz linked_at
+  }
+
+  EXECUTIONS {
+    bigint execution_id PK
+    bigint vault_id FK
+    text   action_type
+    text   status
+    text   asset_symbol
+    text   asset_address
+    numeric amount_asset
+    int     asset_decimals
+    numeric amount_usd
+    text   from_protocol
+    text   to_protocol
+    numeric apy_at_execution
+    text   tx_hash
+    timestamptz timestamp
+    bigint block_number
+  }

--- a/db/giza-vaults/postgres/migrations/0001_init.sql
+++ b/db/giza-vaults/postgres/migrations/0001_init.sql
@@ -1,0 +1,62 @@
+DO $$ BEGIN
+  CREATE TYPE action_type_enum AS ENUM ('deposit','withdraw','transfer');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE status_enum AS ENUM ('pending','completed','failed');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS vaults (
+  vault_id         BIGSERIAL PRIMARY KEY,
+  chain_id         TEXT NOT NULL,
+  factory_address  TEXT NOT NULL,
+  vault_address    TEXT NOT NULL,
+  created_at       TIMESTAMPTZ NOT NULL,
+  created_block    BIGINT,
+  CONSTRAINT uq_vault UNIQUE (chain_id, vault_address)
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  user_id        BIGSERIAL PRIMARY KEY,
+  wallet_address TEXT NOT NULL UNIQUE,
+  first_seen_at  TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS user_vaults (
+  id         BIGSERIAL PRIMARY KEY,
+  vault_id   BIGINT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE,
+  user_id    BIGINT NOT NULL REFERENCES users(user_id)  ON DELETE CASCADE,
+  linked_at  TIMESTAMPTZ DEFAULT now(),
+  CONSTRAINT uq_user_vault UNIQUE (vault_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS executions (
+  execution_id       BIGSERIAL PRIMARY KEY,
+  vault_id           BIGINT NOT NULL REFERENCES vaults(vault_id) ON DELETE CASCADE,
+  action_type        action_type_enum NOT NULL,
+  status             status_enum NOT NULL,
+  asset_symbol       TEXT,
+  asset_address      TEXT,
+  asset_decimals     INT,
+  amount_asset       NUMERIC(78, 0),          -- raw units (no decimals)
+  amount_usd         NUMERIC(38, 10),         -- normalized USD value
+  from_protocol      TEXT,
+  to_protocol        TEXT,
+  apy_at_execution   NUMERIC(10, 6),
+  tx_hash            TEXT NOT NULL,
+  timestamp          TIMESTAMPTZ NOT NULL,
+  block_number       BIGINT,
+  CONSTRAINT uq_tx UNIQUE (tx_hash, vault_id),
+  CONSTRAINT ck_transfer_requires_to CHECK (
+    (action_type <> 'transfer') OR (to_protocol IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS ix_vaults_factory ON vaults(factory_address);
+CREATE INDEX IF NOT EXISTS ix_vaults_chain_addr ON vaults(chain_id, vault_address);
+CREATE INDEX IF NOT EXISTS ix_uv_user ON user_vaults(user_id);
+CREATE INDEX IF NOT EXISTS ix_uv_vault ON user_vaults(vault_id);
+CREATE INDEX IF NOT EXISTS ix_exec_vault_time ON executions(vault_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS ix_exec_status ON executions(status);
+CREATE INDEX IF NOT EXISTS ix_exec_protocol ON executions((COALESCE(to_protocol, from_protocol)));
+CREATE INDEX IF NOT EXISTS ix_exec_asset ON executions(asset_symbol);

--- a/db/giza-vaults/postgres/migrations/0002_views.sql
+++ b/db/giza-vaults/postgres/migrations/0002_views.sql
@@ -1,0 +1,35 @@
+CREATE OR REPLACE VIEW v_vaults_from_factory AS
+SELECT chain_id, factory_address, vault_address, created_at, created_block, vault_id
+FROM vaults;
+
+CREATE OR REPLACE VIEW v_vault_user_associations AS
+SELECT v.vault_id, v.chain_id, v.vault_address, u.user_id, u.wallet_address, uv.linked_at
+FROM user_vaults uv
+JOIN users u  ON u.user_id  = uv.user_id
+JOIN vaults v ON v.vault_id = uv.vault_id;
+
+CREATE OR REPLACE VIEW v_execution_history AS
+SELECT
+  e.execution_id, e.vault_id, v.chain_id, v.vault_address,
+  e.action_type, e.status,
+  e.asset_symbol, e.asset_address, e.asset_decimals,
+  e.amount_asset, e.amount_usd,
+  COALESCE(e.to_protocol, e.from_protocol) AS protocol,
+  e.apy_at_execution, e.tx_hash, e.timestamp, e.block_number
+FROM executions e
+JOIN vaults v ON v.vault_id = e.vault_id;
+
+CREATE OR REPLACE VIEW v_agent_tx_history AS
+SELECT
+  v.chain_id,
+  v.vault_address,
+  e.tx_hash,
+  e.action_type,
+  e.status,
+  e.asset_symbol,
+  e.amount_usd,
+  COALESCE(e.to_protocol, e.from_protocol) AS protocol,
+  e.apy_at_execution,
+  e.timestamp
+FROM executions e
+JOIN vaults v ON v.vault_id = e.vault_id;

--- a/db/giza-vaults/postgres/migrations/0003_upserts.sql
+++ b/db/giza-vaults/postgres/migrations/0003_upserts.sql
@@ -1,0 +1,70 @@
+CREATE OR REPLACE FUNCTION upsert_vault(
+  p_chain_id TEXT,
+  p_factory_address TEXT,
+  p_vault_address TEXT,
+  p_created_at TIMESTAMPTZ,
+  p_created_block BIGINT
+) RETURNS BIGINT AS $$
+DECLARE vid BIGINT;
+BEGIN
+  INSERT INTO vaults(chain_id, factory_address, vault_address, created_at, created_block)
+  VALUES (p_chain_id, p_factory_address, p_vault_address, p_created_at, p_created_block)
+  ON CONFLICT (chain_id, vault_address)
+  DO UPDATE SET factory_address = EXCLUDED.factory_address,
+                created_at = LEAST(vaults.created_at, EXCLUDED.created_at),
+                created_block = COALESCE(vaults.created_block, EXCLUDED.created_block)
+  RETURNING vault_id INTO vid;
+  RETURN vid;
+END; $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION upsert_user(p_wallet TEXT) RETURNS BIGINT AS $$
+DECLARE uid BIGINT;
+BEGIN
+  INSERT INTO users(wallet_address) VALUES (p_wallet)
+  ON CONFLICT (wallet_address) DO NOTHING;
+  SELECT user_id INTO uid FROM users WHERE wallet_address = p_wallet;
+  RETURN uid;
+END; $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION link_user_vault(p_vault_id BIGINT, p_user_id BIGINT) RETURNS VOID AS $$
+BEGIN
+  INSERT INTO user_vaults(vault_id, user_id) VALUES (p_vault_id, p_user_id)
+  ON CONFLICT (vault_id, user_id) DO NOTHING;
+END; $$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION upsert_execution(
+  p_vault_id BIGINT,
+  p_action action_type_enum,
+  p_status status_enum,
+  p_asset_symbol TEXT,
+  p_asset_address TEXT,
+  p_asset_decimals INT,
+  p_amount_asset NUMERIC,
+  p_amount_usd NUMERIC,
+  p_from_protocol TEXT,
+  p_to_protocol TEXT,
+  p_apy NUMERIC,
+  p_tx_hash TEXT,
+  p_timestamp TIMESTAMPTZ,
+  p_block BIGINT
+) RETURNS BIGINT AS $$
+DECLARE eid BIGINT;
+BEGIN
+  INSERT INTO executions(
+    vault_id, action_type, status, asset_symbol, asset_address, asset_decimals,
+    amount_asset, amount_usd, from_protocol, to_protocol, apy_at_execution,
+    tx_hash, timestamp, block_number
+  ) VALUES (
+    p_vault_id, p_action, p_status, p_asset_symbol, p_asset_address, p_asset_decimals,
+    p_amount_asset, p_amount_usd, p_from_protocol, p_to_protocol, p_apy,
+    p_tx_hash, p_timestamp, p_block
+  )
+  ON CONFLICT (tx_hash, vault_id)
+  DO UPDATE SET status = EXCLUDED.status,
+                amount_usd = COALESCE(EXCLUDED.amount_usd, executions.amount_usd),
+                apy_at_execution = COALESCE(EXCLUDED.apy_at_execution, executions.apy_at_execution),
+                block_number = COALESCE(EXCLUDED.block_number, executions.block_number),
+                timestamp = LEAST(executions.timestamp, EXCLUDED.timestamp)
+  RETURNING execution_id INTO eid;
+  RETURN eid;
+END; $$ LANGUAGE plpgsql;

--- a/db/giza-vaults/postgres/migrations/0004_roles.sql
+++ b/db/giza-vaults/postgres/migrations/0004_roles.sql
@@ -1,0 +1,7 @@
+DO $$ BEGIN CREATE ROLE etl_writer LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE ROLE api_reader LOGIN; EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+GRANT USAGE ON SCHEMA public TO etl_writer, api_reader;
+GRANT SELECT, INSERT, UPDATE ON vaults, users, user_vaults, executions TO etl_writer;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO etl_writer;
+GRANT SELECT ON v_vaults_from_factory, v_vault_user_associations, v_execution_history, v_agent_tx_history TO api_reader;

--- a/db/giza-vaults/postgres/ops/SET_ROLE_PASSWORDS.sql
+++ b/db/giza-vaults/postgres/ops/SET_ROLE_PASSWORDS.sql
@@ -1,0 +1,5 @@
+-- TEMPLATE ONLY. Copy this to ops/SET_ROLE_PASSWORDS.sql (DO NOT COMMIT THAT COPY).
+-- Replace the placeholders with real passwords and run once per environment.
+
+ALTER ROLE etl_writer WITH PASSWORD 'bond.credit';
+ALTER ROLE api_reader WITH PASSWORD 'bond.credit';

--- a/db/giza-vaults/postgres/package-lock.json
+++ b/db/giza-vaults/postgres/package-lock.json
@@ -1,0 +1,254 @@
+{
+  "name": "giza-vaults-db",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "giza-vaults-db",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^3.3.2",
+        "pg": "^8.16.3"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/db/giza-vaults/postgres/package.json
+++ b/db/giza-vaults/postgres/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "giza-vaults-db",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "node-fetch": "^3.3.2",
+    "pg": "^8.16.3"
+  }
+}

--- a/db/giza-vaults/postgres/scripts/db_ping.js
+++ b/db/giza-vaults/postgres/scripts/db_ping.js
@@ -1,0 +1,19 @@
+import pg from "pg";
+
+const pool = new pg.Pool({
+  host: "127.0.0.1",   // ← avoids IPv6 (::1) resolution weirdness on Windows
+  port: 5433,          // you mapped 5433->5432 in docker compose
+  user: "giza",        // start with the superuser you know works
+  password: "supersecret",
+  database: "giza_db",
+  ssl: false,
+  keepAlive: true,
+  connectionTimeoutMillis: 8000,
+});
+
+try {
+  const { rows } = await pool.query("select current_database() as db, current_user as usr");
+  console.log(rows[0]);
+} finally {
+  await pool.end();
+}

--- a/db/giza-vaults/postgres/scripts/ingest_giza_api.cjs
+++ b/db/giza-vaults/postgres/scripts/ingest_giza_api.cjs
@@ -1,0 +1,121 @@
+// scripts/ingest_giza_api.js
+import fetch from "node-fetch";
+import pg from "pg";
+
+/**
+ * EDIT THESE to match your setup
+ * - If running from Windows host, use localhost:5433
+ * - If you run this inside a Docker container next to Postgres, use host "db" and port 5432
+ */
+const pool = new pg.Pool({
+  host: "localhost",
+  port: 5433,
+  user: "etl_writer",   // from 0004_roles.sql
+  password: "etl_pw",   // from 0004_roles.sql
+  database: "giza_db",
+});
+
+// 🔁 Replace with your teammate’s real API endpoint and params
+const GIZA_API_URL = "/agent/{chain_id}/giza/{id}/tx_history"; // placeholder
+
+async function upsertVault(client, v) {
+  // Map your API fields here
+  const chainId = v.chainId || "base";
+  const factory = v.factoryAddress;
+  const vaultAddr = v.vaultAddress;
+  const createdAt = new Date(v.createdAt * 1000); // or v.createdAt_iso if already ISO
+  const createdBlock = BigInt(v.createdBlock);
+
+  const res = await client.query(
+    "SELECT upsert_vault($1,$2,$3,$4,$5) AS vault_id",
+    [chainId, factory, vaultAddr, createdAt, createdBlock]
+  );
+  return res.rows[0].vault_id;
+}
+
+async function linkAdmins(client, vaultId, admins) {
+  for (const w of admins || []) {
+    const { rows } = await client.query("SELECT upsert_user($1) AS user_id", [w]);
+    const userId = rows[0].user_id;
+    await client.query("SELECT link_user_vault($1,$2)", [vaultId, userId]);
+  }
+}
+
+function mapActionType(a) {
+  const x = (a || "").toLowerCase();
+  if (x.startsWith("dep")) return "deposit";
+  if (x.startsWith("with")) return "withdraw";
+  if (x.startsWith("tran")) return "transfer";
+  return "deposit";
+}
+function mapStatus(s) {
+  const x = (s || "").toLowerCase();
+  if (x.includes("fail")) return "failed";
+  if (x.includes("pend")) return "pending";
+  return "completed";
+}
+
+async function upsertExecutions(client, vaultId, execs) {
+  for (const e of execs || []) {
+    const action = mapActionType(e.actionType);
+    const status = mapStatus(e.status);
+    const assetSymbol = e.asset?.symbol || null;
+    const assetAddress = e.asset?.address || null;
+    const assetDecimals = Number(e.asset?.decimals ?? 0);
+    const amountAsset = e.amountRaw ?? e.amount_asset_raw ?? 0;  // integer/raw
+    const amountUsd = e.amountUsd ?? null;
+    const fromProtocol = e.fromProtocol ?? null;
+    const toProtocol = e.toProtocol ?? null;
+    const apy = e.apyAtExecution ?? null;
+    const txHash = e.txHash;
+    const timestamp = new Date((e.timestampSec ?? e.timestamp) * 1000); // adjust if ISO already
+    const block = BigInt(e.blockNumber ?? 0);
+
+    await client.query(
+      `SELECT upsert_execution(
+        $1, $2::action_type_enum, $3::status_enum,
+        $4, $5, $6,
+        $7, $8, $9, $10, $11, $12, $13, $14
+      )`,
+      [
+        vaultId, action, status,
+        assetSymbol, assetAddress, assetDecimals,
+        amountAsset, amountUsd, fromProtocol, toProtocol,
+        apy, txHash, timestamp, block
+      ]
+    );
+  }
+}
+
+async function main() {
+  const client = await pool.connect();
+  try {
+    const resp = await fetch(GIZA_API_URL);
+    if (!resp.ok) throw new Error(`Giza API ${resp.status}`);
+    const data = await resp.json();
+
+    // Expecting something like: { vaults: [ { ... , admins: [...], executions: [...] } ] }
+    const vaults = data.vaults || data || [];
+    for (const v of vaults) {
+      await client.query("BEGIN");
+      try {
+        const vaultId = await upsertVault(client, v);
+        await linkAdmins(client, vaultId, v.admins || v.getAllAdmin || []);
+        await upsertExecutions(client, vaultId, v.executions || []);
+        await client.query("COMMIT");
+        console.log(`Synced vault ${v.vaultAddress} → id ${vaultId}`);
+      } catch (e) {
+        await client.query("ROLLBACK");
+        console.error("Failed vault", v.vaultAddress, e.message);
+      }
+    }
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/db/giza-vaults/postgres/seeds/seed.sql
+++ b/db/giza-vaults/postgres/seeds/seed.sql
@@ -1,0 +1,44 @@
+SET search_path TO public;
+
+-- 1) one vault
+SELECT upsert_vault('base'::text, '0xFactory'::text, '0xVaultA'::text, now(), 123456::bigint) AS vault_id \gset
+
+-- 2) one user, link
+SELECT upsert_user('0xUserWalletA'::text) AS user_id \gset
+SELECT link_user_vault(:vault_id::bigint, :user_id::bigint);
+
+-- 3) one deposit execution
+SELECT upsert_execution(
+  :vault_id::bigint,
+  'deposit'::action_type_enum,
+  'completed'::status_enum,
+  'USDC'::text,
+  '0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::text,
+  6::int,
+  100000000::numeric,
+  100.00::numeric,
+  NULL::text,
+  'AaveV3'::text,
+  0.045::numeric,
+  '0xTXHASH1'::text,
+  now(),
+  123457::bigint
+);
+
+-- 4) a withdrawal
+SELECT upsert_execution(
+  :vault_id::bigint,
+  'withdraw'::action_type_enum,
+  'completed'::status_enum,
+  'USDC'::text,
+  '0xA0b8...'::text,
+  6::int,
+  50000000::numeric,
+  50.00::numeric,
+  'AaveV3'::text,
+  NULL::text,
+  0.0::numeric,
+  '0xTXHASH2'::text,
+  now(),
+  123460::bigint
+);

--- a/db/giza-vaults/scripts/db_ping.js
+++ b/db/giza-vaults/scripts/db_ping.js
@@ -1,0 +1,19 @@
+import pg from "pg";
+
+const pool = new pg.Pool({
+  host: "127.0.0.1",   // ← avoids IPv6 (::1) resolution weirdness on Windows
+  port: 5433,          // you mapped 5433->5432 in docker compose
+  user: "giza",        // start with the superuser you know works
+  password: "supersecret",
+  database: "giza_db",
+  ssl: false,
+  keepAlive: true,
+  connectionTimeoutMillis: 8000,
+});
+
+try {
+  const { rows } = await pool.query("select current_database() as db, current_user as usr");
+  console.log(rows[0]);
+} finally {
+  await pool.end();
+}

--- a/db/giza-vaults/scripts/ingest_giza_api.cjs
+++ b/db/giza-vaults/scripts/ingest_giza_api.cjs
@@ -1,0 +1,121 @@
+// scripts/ingest_giza_api.js
+import fetch from "node-fetch";
+import pg from "pg";
+
+/**
+ * EDIT THESE to match your setup
+ * - If running from Windows host, use localhost:5433
+ * - If you run this inside a Docker container next to Postgres, use host "db" and port 5432
+ */
+const pool = new pg.Pool({
+  host: "localhost",
+  port: 5433,
+  user: "etl_writer",   // from 0004_roles.sql
+  password: "etl_pw",   // from 0004_roles.sql
+  database: "giza_db",
+});
+
+// 🔁 Replace with your teammate’s real API endpoint and params
+const GIZA_API_URL = "/agent/{chain_id}/giza/{id}/tx_history"; // placeholder
+
+async function upsertVault(client, v) {
+  // Map your API fields here
+  const chainId = v.chainId || "base";
+  const factory = v.factoryAddress;
+  const vaultAddr = v.vaultAddress;
+  const createdAt = new Date(v.createdAt * 1000); // or v.createdAt_iso if already ISO
+  const createdBlock = BigInt(v.createdBlock);
+
+  const res = await client.query(
+    "SELECT upsert_vault($1,$2,$3,$4,$5) AS vault_id",
+    [chainId, factory, vaultAddr, createdAt, createdBlock]
+  );
+  return res.rows[0].vault_id;
+}
+
+async function linkAdmins(client, vaultId, admins) {
+  for (const w of admins || []) {
+    const { rows } = await client.query("SELECT upsert_user($1) AS user_id", [w]);
+    const userId = rows[0].user_id;
+    await client.query("SELECT link_user_vault($1,$2)", [vaultId, userId]);
+  }
+}
+
+function mapActionType(a) {
+  const x = (a || "").toLowerCase();
+  if (x.startsWith("dep")) return "deposit";
+  if (x.startsWith("with")) return "withdraw";
+  if (x.startsWith("tran")) return "transfer";
+  return "deposit";
+}
+function mapStatus(s) {
+  const x = (s || "").toLowerCase();
+  if (x.includes("fail")) return "failed";
+  if (x.includes("pend")) return "pending";
+  return "completed";
+}
+
+async function upsertExecutions(client, vaultId, execs) {
+  for (const e of execs || []) {
+    const action = mapActionType(e.actionType);
+    const status = mapStatus(e.status);
+    const assetSymbol = e.asset?.symbol || null;
+    const assetAddress = e.asset?.address || null;
+    const assetDecimals = Number(e.asset?.decimals ?? 0);
+    const amountAsset = e.amountRaw ?? e.amount_asset_raw ?? 0;  // integer/raw
+    const amountUsd = e.amountUsd ?? null;
+    const fromProtocol = e.fromProtocol ?? null;
+    const toProtocol = e.toProtocol ?? null;
+    const apy = e.apyAtExecution ?? null;
+    const txHash = e.txHash;
+    const timestamp = new Date((e.timestampSec ?? e.timestamp) * 1000); // adjust if ISO already
+    const block = BigInt(e.blockNumber ?? 0);
+
+    await client.query(
+      `SELECT upsert_execution(
+        $1, $2::action_type_enum, $3::status_enum,
+        $4, $5, $6,
+        $7, $8, $9, $10, $11, $12, $13, $14
+      )`,
+      [
+        vaultId, action, status,
+        assetSymbol, assetAddress, assetDecimals,
+        amountAsset, amountUsd, fromProtocol, toProtocol,
+        apy, txHash, timestamp, block
+      ]
+    );
+  }
+}
+
+async function main() {
+  const client = await pool.connect();
+  try {
+    const resp = await fetch(GIZA_API_URL);
+    if (!resp.ok) throw new Error(`Giza API ${resp.status}`);
+    const data = await resp.json();
+
+    // Expecting something like: { vaults: [ { ... , admins: [...], executions: [...] } ] }
+    const vaults = data.vaults || data || [];
+    for (const v of vaults) {
+      await client.query("BEGIN");
+      try {
+        const vaultId = await upsertVault(client, v);
+        await linkAdmins(client, vaultId, v.admins || v.getAllAdmin || []);
+        await upsertExecutions(client, vaultId, v.executions || []);
+        await client.query("COMMIT");
+        console.log(`Synced vault ${v.vaultAddress} → id ${vaultId}`);
+      } catch (e) {
+        await client.query("ROLLBACK");
+        console.error("Failed vault", v.vaultAddress, e.message);
+      }
+    }
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/db/giza-vaults/seeds/seed.sql
+++ b/db/giza-vaults/seeds/seed.sql
@@ -1,0 +1,44 @@
+SET search_path TO public;
+
+-- 1) one vault
+SELECT upsert_vault('base'::text, '0xFactory'::text, '0xVaultA'::text, now(), 123456::bigint) AS vault_id \gset
+
+-- 2) one user, link
+SELECT upsert_user('0xUserWalletA'::text) AS user_id \gset
+SELECT link_user_vault(:vault_id::bigint, :user_id::bigint);
+
+-- 3) one deposit execution
+SELECT upsert_execution(
+  :vault_id::bigint,
+  'deposit'::action_type_enum,
+  'completed'::status_enum,
+  'USDC'::text,
+  '0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'::text,
+  6::int,
+  100000000::numeric,
+  100.00::numeric,
+  NULL::text,
+  'AaveV3'::text,
+  0.045::numeric,
+  '0xTXHASH1'::text,
+  now(),
+  123457::bigint
+);
+
+-- 4) a withdrawal
+SELECT upsert_execution(
+  :vault_id::bigint,
+  'withdraw'::action_type_enum,
+  'completed'::status_enum,
+  'USDC'::text,
+  '0xA0b8...'::text,
+  6::int,
+  50000000::numeric,
+  50.00::numeric,
+  'AaveV3'::text,
+  NULL::text,
+  0.0::numeric,
+  '0xTXHASH2'::text,
+  now(),
+  123460::bigint
+);


### PR DESCRIPTION
Context
- Adds normalized Postgres schema & dev stack.
- Adds ClickHouse analytics stack (natural keys, ReplacingMergeTree, views).

What’s included
- postgres/: compose, migrations, seeds, docs
- clickhouse/: compose, migrations, scripts, ERD, ops template

How to run ClickHouse
1) cd db/giza-vaults/clickhouse
2) cp .env.example .env  (CH_PASSWORD=giza_pw_change_me)
3) docker compose up -d
4) pwsh ./scripts/ch_migrate.ps1
5) http://localhost:8123/play (user giza / pw giza_pw_change_me / db giza)

Follow-ups
- Ingest script (subgraph + Giza API)
- /tx_history Fastify endpoint
- Materialized views for scoring windows
